### PR TITLE
Update Python path in processors to reflect changes in macOS 12.3+

### DIFF
--- a/SharedProcessors/AcrobatGUIDPatcher.py
+++ b/SharedProcessors/AcrobatGUIDPatcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/BMSImporter.py
+++ b/SharedProcessors/BMSImporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/CharToNum.py
+++ b/SharedProcessors/CharToNum.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2020 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/ChromiumSettings.py
+++ b/SharedProcessors/ChromiumSettings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2020 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/CreateNextBuild.py
+++ b/SharedProcessors/CreateNextBuild.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/DateTimeStamps.py
+++ b/SharedProcessors/DateTimeStamps.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/ExecuteFile.py
+++ b/SharedProcessors/ExecuteFile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2020 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/FileDateVersionSubst.py
+++ b/SharedProcessors/FileDateVersionSubst.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/FileMoverFromList.py
+++ b/SharedProcessors/FileMoverFromList.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSBuildRun.py
+++ b/SharedProcessors/MSBuildRun.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIAddFileHash.py
+++ b/SharedProcessors/MSIAddFileHash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2021 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIAddRecord.py
+++ b/SharedProcessors/MSIAddRecord.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIApplySumInfo.py
+++ b/SharedProcessors/MSIApplySumInfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIDbWorker.py
+++ b/SharedProcessors/MSIDbWorker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIRunSQL.py
+++ b/SharedProcessors/MSIRunSQL.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIRunSQLget.py
+++ b/SharedProcessors/MSIRunSQLget.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSITransformer.py
+++ b/SharedProcessors/MSITransformer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIimportMergeModule.py
+++ b/SharedProcessors/MSIimportMergeModule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MSIofflinePatcher.py
+++ b/SharedProcessors/MSIofflinePatcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MozillaAddonIntegrator.py
+++ b/SharedProcessors/MozillaAddonIntegrator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2020 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/MozillaOmniUpdate.py
+++ b/SharedProcessors/MozillaOmniUpdate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2020 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/NANTrun.py
+++ b/SharedProcessors/NANTrun.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/ResourceExtractor.py
+++ b/SharedProcessors/ResourceExtractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/SevenZipExtractor.py
+++ b/SharedProcessors/SevenZipExtractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2015 The Pennsylvania State University.
 #

--- a/SharedProcessors/TextFileSearcher.py
+++ b/SharedProcessors/TextFileSearcher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/WinPEVersionExtractor.py
+++ b/SharedProcessors/WinPEVersionExtractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/WixDarkExtractor.py
+++ b/SharedProcessors/WixDarkExtractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #

--- a/SharedProcessors/WixDefaults.py
+++ b/SharedProcessors/WixDefaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2019 Swiss federal institute of technology (ETHZ).
 #


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. This pull request adjusts the "shebang" interpreter paths of processors to replace `/usr/bin/python` with the AutoPkg Python 3 path.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.

Thank you for your consideration!