### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Keepass/Keepass-LANG.download.recipe.yaml
+++ b/Keepass/Keepass-LANG.download.recipe.yaml
@@ -16,7 +16,7 @@ Process:
 - Processor: URLTextSearcher
   Arguments:
     re_pattern: '%SEARCH_URL_GER%'
-    url: http://sourceforge.net/api/file/index/project-id/95013/rss
+    url: https://sourceforge.net/api/file/index/project-id/95013/rss
 
 - Processor: URLDownloader
   Arguments:
@@ -27,7 +27,7 @@ Process:
 - Processor: URLTextSearcher
   Arguments:
     re_pattern: '%SEARCH_URL_FRA%'
-    url: http://sourceforge.net/api/file/index/project-id/95013/rss
+    url: https://sourceforge.net/api/file/index/project-id/95013/rss
 
 - Processor: URLDownloader
   Arguments:
@@ -38,7 +38,7 @@ Process:
 - Processor: URLTextSearcher
   Arguments:
     re_pattern: '%SEARCH_URL_ITA%'
-    url: http://sourceforge.net/api/file/index/project-id/95013/rss
+    url: https://sourceforge.net/api/file/index/project-id/95013/rss
 
 - Processor: URLDownloader
   Arguments:
@@ -49,7 +49,7 @@ Process:
 - Processor: URLTextSearcher
   Arguments:
     re_pattern: '%SEARCH_URL_SPA%'
-    url: http://sourceforge.net/api/file/index/project-id/95013/rss
+    url: https://sourceforge.net/api/file/index/project-id/95013/rss
 
 - Processor: URLDownloader
   Arguments:

--- a/Keepass/Keepass-MSI.download.recipe.yaml
+++ b/Keepass/Keepass-MSI.download.recipe.yaml
@@ -12,7 +12,7 @@ Process:
 - Processor: URLTextSearcher
   Arguments:
     re_pattern: '%SEARCH_URL_MSI%'
-    url: http://sourceforge.net/api/file/index/project-id/95013/rss
+    url: https://sourceforge.net/api/file/index/project-id/95013/rss
 
 - Processor: URLDownloader
   Arguments:


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso).

Thanks for considering!