### PR TITLE
[TIME SENSITIVE] Replace all instances of RenameVar processor with native var substitution

### DIFF
--- a/7-Zip/7-Zip-Win.BMS.recipe.yaml
+++ b/7-Zip/7-Zip-Win.BMS.recipe.yaml
@@ -16,7 +16,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -68,9 +68,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/7-Zip/7-Zip-Win.build.recipe.yaml
+++ b/7-Zip/7-Zip-Win.build.recipe.yaml
@@ -26,26 +26,21 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '2'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\read\create-log-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\read\readme-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_64_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%.msi'
 
@@ -57,6 +52,6 @@ Process:
       /j: '%NAME% %version% ML'
       /o: 'Altered version for enterprise. %us_date% by AutoPkg'
       /t: '%NAME% %version% ML'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_64_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/7-Zip/7-Zip-Win64.BMS.recipe.yaml
+++ b/7-Zip/7-Zip-Win64.BMS.recipe.yaml
@@ -16,7 +16,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -77,9 +77,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/7-Zip/7-Zip-Win64.build.recipe.yaml
+++ b/7-Zip/7-Zip-Win64.build.recipe.yaml
@@ -27,49 +27,44 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '2'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%.msi'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   # Comment: Extract the InstantClient odbc zip archive
   # Arguments:
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    # exe_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    # extract_dir: '%BUILD_DIR%\%NAME%_%build_ver%_ML\sourceunzipped\'
     # extract_file: '_7zG.exe'
     # ignore_pattern: ''
     # preserve_paths: 'False'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\_7zG.exe'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\7-Zip_256.ico'
+    # source_app: '%BUILD_DIR%\%NAME%_%build_ver%_ML\sourceunzipped\_7zG.exe'
+    source_app: '%BUILD_DIR%\%NAME%_%build_ver%_ML\helpers\7-Zip_256.ico'
     # msi_icon_name: 'ProductIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -83,6 +78,6 @@ Process:
       /j: '%NAME% %version% ML'
       /o: 'Altered version for enterprise. %us_date% by AutoPkg'
       /t: '%NAME% %version% ML'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Adobe/AcrobatDC-Win.build.recipe.yaml
+++ b/Adobe/AcrobatDC-Win.build.recipe.yaml
@@ -27,17 +27,12 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read:helpers
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     pkg_dir: '%NAME2%%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
  
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: get the directories from ITShop-win
   Arguments:
@@ -46,7 +41,7 @@ Process:
     - copy
     - /Y
     - '"%ACRO_SOURCE%\AcroPro.msi"'
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\AcroPro.msi'
+    - '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\AcroPro.msi'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
@@ -58,7 +53,7 @@ Process:
     - copy
     - /Y
     - '"%ACRO_SOURCE%\*.cab"'
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    - '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
@@ -70,24 +65,24 @@ Process:
     # - copy
     # - /Y
     # - '"%ACRO_SOURCE%\1031.mst"'
-    # - '%BUILD_DIR%\%pkg_dir%\release\AcroDC-AutoPkg_1031.mst'
+    # - '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroDC-AutoPkg_1031.mst'
     # exe_file: 'cmd.exe'
     # exe_folder: '%RECIPE_CACHE_DIR%'
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-AcrobatProDC_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-AcrobatProDC_%ver_major%.%ver_majorminor%.%ver_minor%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[1][9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-AcrobatProDC_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-AcrobatProDC_%ver_major%.%ver_majorminor%.%ver_minor%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[1][9]\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\AdobeAcrobatDCUpd%version_string%.msp'
+    destination_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\AdobeAcrobatDCUpd%version_string%.msp'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -102,12 +97,12 @@ Process:
     msp_path: sourceunzipped\AdobeAcrobatDCUpd%version_string%.msp
     new_msi_path: adm\AcroProDC_%version_string%_ML.msi
     new_packcode: 'True'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
+    pkg_dir_abs: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/AcrobatGUIDPatcher
   Arguments:
     base_GUID: '{AC76BA86-1033-FFFF-7760-0C0F074E4100}'
-    new_ver: '%version%'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     old_hex_ver: 0F074E41
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -115,25 +110,25 @@ Process:
     SQL_command:
     - UPDATE `Property` SET `Property`.`Value`='%newGUID%' WHERE `Property`.`Property`='ProductCode'
     - UPDATE `Directory` SET `Directory`.`DefaultDir`='PAC76B~1|%newGUID%' WHERE `Directory`.`Directory`='CACHE_DIR'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroProDC_%version_string%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\adm\AcroProDC_%version_string%_ML.msi'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\AcroProDC_%version_string%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroProDC_%version_string%_ML.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroProDC_%version_string%_ML.msi'
+    source_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\adm\AcroProDC_%version_string%_ML.msi'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\Data1.cab'
+    # destination_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\Data1.cab'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\adm\Data1.cab'
+    # source_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Data1.cab'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\Data2.cab'
+    # destination_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\Data2.cab'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\adm\Data2.cab'
+    # source_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Data2.cab'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: get the CAB-files
@@ -142,7 +137,7 @@ Process:
     - /C
     - dir
     - /b
-    - '%BUILD_DIR%\%pkg_dir%\adm\Data*.cab'
+    - '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Data*.cab'
     - '>'
     - cabfiles.txt
     exe_file: 'cmd.exe'
@@ -151,22 +146,22 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
     file_list: '%RECIPE_CACHE_DIR%\cabfiles.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\adm'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\release'
+    source_dir: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\adm'
+    target_dir: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplyTransform
   # Arguments:
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroProDC_%version_string%_ML.msi'
+    # msi_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroProDC_%version_string%_ML.msi'
     # mst_paths:
-    # - '%BUILD_DIR%\%pkg_dir%\helpers\AcroProDC-ethz-22030x.mst'
+    # - '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\AcroProDC-ethz-22030x.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Applies the transforms to the AcroProDC_xx.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroProDC_%version_string%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroProDC_%version_string%_ML.msi'
     mst_paths:
-    - '%BUILD_DIR%\%pkg_dir%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
+    - '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
@@ -180,16 +175,16 @@ Process:
     - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='AcroProDC_%version_string%_ML.msi', `MoveFile`.`DestName`='AcroProDC_%version_string%_ML.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
     - DELETE FROM `DeleteFiles` WHERE `DeleteFiles`.`DeleteFiles`='drvDX8_x3d'
     - UPDATE `Component` SET `Component`.`Condition`='CHROMEPLUGIN' WHERE `Component`.`Component`='WCChromeNativeMessagingHost'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroProDC_%version_string%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroProDC_%version_string%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adobe Acrobat Pro DC %version%
+      /j: Adobe Acrobat Pro DC %ver_major%.%ver_majorminor%.%ver_minor%
       /o: Altered and hardened version for corporate use. %us_date% by AutoPkg
-      /t: Adobe Acrobat Pro DC %version%
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroProDC_%version_string%_ML.msi'
+      /t: Adobe Acrobat Pro DC %ver_major%.%ver_majorminor%.%ver_minor%
+    msi_path: '%BUILD_DIR%\%NAME2%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroProDC_%version_string%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Adobe/AcrobatDC-Win.download.recipe.yaml
+++ b/Adobe/AcrobatDC-Win.download.recipe.yaml
@@ -21,16 +21,6 @@ Process:
     re_pattern: /AcrobatDCUpd(?P<version_string>(?P<ver_major>[0-9]{2})(?P<ver_majorminor>[0-9]{3})(?P<ver_minor>[0-9]{5}))\.msp
     url: https://www.adobe.com/devnet-docs/acrobatetk/tools/ReleaseNotesDC/%match%
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%.%ver_majorminor%.%ver_minor%'
-    rename_var: version
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%,%ver_majorminor%,%ver_minor%'
-    rename_var: ASver
-
 - Processor: URLDownloader
   Arguments:
     CHECK_FILESIZE_ONLY: 'False'

--- a/Adobe/AcrobatDC-Win64.build.recipe.yaml
+++ b/Adobe/AcrobatDC-Win64.build.recipe.yaml
@@ -25,17 +25,12 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
  
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: get the directories from ITShop-win
   Arguments:
@@ -44,7 +39,7 @@ Process:
     - copy
     - /Y
     - '"%ACRO_SOURCE%\AcroPro.msi"'
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\AcroPro.msi'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\AcroPro.msi'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
@@ -56,7 +51,7 @@ Process:
     - copy
     - /Y
     - '"%ACRO_SOURCE%\*.cab"'
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
@@ -68,25 +63,25 @@ Process:
     - copy
     - /Y
     - '"%ACRO_SOURCE%\1031.mst"'
-    - '%BUILD_DIR%\%pkg_dir%\release\AcroDC-AutoPkg_1031.mst'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroDC-AutoPkg_1031.mst'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
     
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -101,12 +96,12 @@ Process:
     msp_path: sourceunzipped\%DOWNLOAD_FILE%
     new_msi_path: adm\AcroProDC_%version_string%_ML.msi
     new_packcode: 'True'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
+    pkg_dir_abs: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/AcrobatGUIDPatcher
   Arguments:
     base_GUID: '{AC76BA86-1033-FFFF-7760-BC15014EA700}'
-    new_ver: '%version%'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     old_hex_ver: 15014EA7
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -118,25 +113,25 @@ Process:
     - DELETE FROM `Media` WHERE `Media`.`Cabinet`='Optional.cab'
     - DELETE FROM `Media` WHERE `Media`.`Cabinet`='AlfSdPack.cab'
     - DELETE FROM `Media` WHERE `Media`.`Cabinet`='Languages.cab'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroProDC_%version_string%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\AcroProDC_%version_string%_ML.msi'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroProDC_%version_string%_ML.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\AcroProDC_%version_string%_ML.msi'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\Data1.cab'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\Data1.cab'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\adm\Data1.cab'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Data1.cab'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\Data2.cab'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\Data2.cab'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\adm\Data2.cab'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Data2.cab'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: get the CAB-files
@@ -145,7 +140,7 @@ Process:
     - /C
     - dir
     - /b
-    - '%BUILD_DIR%\%pkg_dir%\adm\Data*.cab'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Data*.cab'
     - '>'
     - cabfiles.txt
     exe_file: 'cmd.exe'
@@ -154,16 +149,16 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
     file_list: '%RECIPE_CACHE_DIR%\cabfiles.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\adm'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\release'
+    source_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm'
+    target_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Applies the transforms to the AcroProDC_xx.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
     mst_paths:
-    - '%BUILD_DIR%\%pkg_dir%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
@@ -174,18 +169,18 @@ Process:
     - DELETE FROM `MoveFile` WHERE `MoveFile`.`FileKey`='CacheSetupFiles_WindowsInstaller_KB893803_v2_x86.exe'
     - DELETE FROM `MoveFile` WHERE `MoveFile`.`FileKey`='CacheSetupFiles_setup.ini'
     - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='Data2.cab', `MoveFile`.`DestName`='Data2.cab' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_Setup.exe'
-    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
+    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
     - DELETE FROM `DeleteFiles` WHERE `DeleteFiles`.`DeleteFiles`='drvDX8_x3d'
     - UPDATE `Component` SET `Component`.`Condition`='CHROMEPLUGIN' WHERE `Component`.`Component`='WCChromeNativeMessagingHost'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adobe Acrobat Pro DC %version%
+      /j: Adobe Acrobat Pro DC %ver_major%.%ver_majorminor%.%ver_minor%
       /o: Altered and hardened version for corporate use. %us_date% by AutoPkg
-      /t: Adobe Acrobat Pro DC %version%
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adobe Acrobat Pro DC %ver_major%.%ver_majorminor%.%ver_minor%
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
 - Processor: EndOfCheckPhase

--- a/Adobe/AcrobatDC-Win64.download.recipe.yaml
+++ b/Adobe/AcrobatDC-Win64.download.recipe.yaml
@@ -33,16 +33,6 @@ Process:
     re_pattern: /AcrobatDCx64Upd(?P<version_string>(?P<ver_major>[0-9]{2})(?P<ver_majorminor>[0-9]{3})(?P<ver_minor>[0-9]{5}))\.msp
     url: https://www.adobe.com/devnet-docs/acrobatetk/tools/ReleaseNotesDC/%match%
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%.%ver_majorminor%.%ver_minor%'
-    rename_var: version
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%,%ver_majorminor%,%ver_minor%'
-    rename_var: ASver
-
 - Processor: URLDownloader
   Arguments:
     # CHECK_FILESIZE_ONLY: 'False'

--- a/Adobe/AcrobatReaderDC-Win64.BMS.recipe.yaml
+++ b/Adobe/AcrobatReaderDC-Win64.BMS.recipe.yaml
@@ -21,19 +21,19 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     BASEVERSION: '%msi_value%'
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     PRODUCTNAME: '%msi_value%'
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -54,7 +54,7 @@ Process:
   Comment: get the summary info from the MSI
   Arguments:
     cmnds_sinfo: ''
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
 
 - Processor: com.github.jazzace.processors/TextSearcher
   Arguments:
@@ -124,10 +124,10 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%BASEVER_US%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%BASEVER_US%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%BASEVERSION%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%BASEVER_US%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%BASEVERSION%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%BASEVER_US%\DEV'
     
 - Processor: com.github.NickETH.recipes.SharedProcessors/BMSImporter
   Comment: Import the MSP application update into Baramundi (BMS) QSS
@@ -194,9 +194,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.msp|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.msp|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Adobe/AcrobatReaderDC-Win64.build.recipe.yaml
+++ b/Adobe/AcrobatReaderDC-Win64.build.recipe.yaml
@@ -20,40 +20,35 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-x64.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-x64.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the AcrobatReaderDC-Win64 installer
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-x64.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-x64.exe'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -64,41 +59,41 @@ Process:
     # cab_dir: adm
     # cab_file: Data1
     # embed_cab: 'True'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%\AcroPro.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%\AcroPro.msi'
     # msp_path: sourceunzipped\%NAME%\AcroRdrDCx64Upd%version_string%.msp
     # new_msi_path: adm\AcroRdrDCx64Upd%version_string%.msi
     # new_packcode: 'True'
-    # pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
+    # pkg_dir_abs: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/AcrobatGUIDPatcher
   # Arguments:
     # base_GUID: '{AC76BA86-1031-1033-7760-BC15014EA700}'
-    # new_ver: '%version%'
+    # new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     # old_hex_ver: 15014EA7
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\AcroRdrDCx64Upd%version_string%.msp'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroRdrDCx64Upd%version_string%.msp'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%\AcroRdrDCx64Upd%version_string%.msp'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%\AcroRdrDCx64Upd%version_string%.msp'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%\AcroPro.msi'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%\AcroPro.msi'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%\*.cab'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%\*.cab'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Files2Move.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\release'
+    file_list: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Files2Move.txt'
+    source_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%'
+    target_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release'
  
 # - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   # Arguments:
@@ -107,39 +102,39 @@ Process:
     # - UPDATE `Property` SET `Property`.`Value`='%newGUID%' WHERE `Property`.`Property`='ProductCode'
     # - UPDATE `Property` SET `Property`.`Value`='Adobe Acrobat Reader DC DE-EN' WHERE `Property`.`Property`='ProductName'
     # - UPDATE `Component` SET `Component`.`Condition`='CHROMEPLUGIN' WHERE `Component`.`Component`='WCChromeNativeMessagingHost'
-    # - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroRdrDCx64Upd%version_string%.msi'
+    # - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\AcroRdrDCx64Upd%version_string%.msi'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Applies the transforms to the AcroPro.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
     mst_paths:
-    - '%BUILD_DIR%\%pkg_dir%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
-    - '%BUILD_DIR%\%pkg_dir%\helpers\JavaScript_Disable_byAutoPkg.mst'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\JavaScript_Disable_byAutoPkg.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
-    - UPDATE `Registry` SET `Registry`.`Value`='%ASver%' WHERE `Registry`.`Registry`='RegHKLM2'
-    - UPDATE `Registry` SET `Registry`.`Value`='%ASver%' WHERE `Registry`.`Registry`='Reg64HKLM2'
-    # - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    - UPDATE `Registry` SET `Registry`.`Value`='%ver_major%,%ver_majorminor%,%ver_minor%' WHERE `Registry`.`Registry`='RegHKLM2'
+    - UPDATE `Registry` SET `Registry`.`Value`='%ver_major%,%ver_majorminor%,%ver_minor%' WHERE `Registry`.`Registry`='Reg64HKLM2'
+    # - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAMELONG%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\adm\Program Files 64\Adobe\Acrobat DC\Acrobat\Acrobat.exe'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Program Files 64\Adobe\Acrobat DC\Acrobat\Acrobat.exe'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
     msi_icon_name: '_SC_Acrobat.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAMELONG%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAMELONG%.png'
@@ -153,6 +148,6 @@ Process:
       /j: Acrobat Reader DC
       /o: Altered and hardened version for corporate use. %us_date% by AutoPkg
       /t: Acrobat Reader DC
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AcroPro.msi'
 
 - Processor: EndOfCheckPhase

--- a/Adobe/AdobeReaderDC-Win.build.recipe.yaml
+++ b/Adobe/AdobeReaderDC-Win.build.recipe.yaml
@@ -16,21 +16,21 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read:helpers
-    org_ver: '%version%'
-    pkg_dir: AdobeReaderDC_%version%_deu
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
+    pkg_dir: AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_deu
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-AdobeReaderDC_%version%_deu.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_deu.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-AdobeReaderDC_%version%_deu.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_deu.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
@@ -54,7 +54,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/AcrobatGUIDPatcher
   Arguments:
     base_GUID: '{AC76BA86-7AD7-1031-7B44-AC0F074E4100}'
-    new_ver: '%version%'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     old_hex_ver: 0F074E41
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -63,12 +63,12 @@ Process:
     - UPDATE `Property` SET `Property`.`Value`='%newGUID%' WHERE `Property`.`Property`='ProductCode'
     - UPDATE `Property` SET `Property`.`Value`='Adobe Acrobat Reader DC DE-EN' WHERE `Property`.`Property`='ProductName'
     - UPDATE `Component` SET `Component`.`Condition`='CHROMEPLUGIN' WHERE `Component`.`Component`='WCChromeNativeMessagingHost'
-    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='AdobeReaderDC_%version%_Deu.msi', `MoveFile`.`DestName`='AdobeReaderDC_%version%_Deu.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroRdrDC1501720050_de_DE.msi'
+    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi', `MoveFile`.`DestName`='AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroRdrDC1501720050_de_DE.msi'
     msi_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroRdrDC%version_string%_de_DE.msi'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%version%_Deu.msi'
+    destination_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi'
     overwrite: 'true'
     source_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroRdrDC%version_string%_de_DE.msi'
 
@@ -76,7 +76,7 @@ Process:
   Comment: Applies the transforms to the AdobeReaderDC.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%version%_Deu.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi'
     mst_paths:
     - '%BUILD_DIR%\%pkg_dir%\helpers\CurrentUser1.mst'
     - '%BUILD_DIR%\%pkg_dir%\helpers\ActiveSetup1.mst'
@@ -91,10 +91,10 @@ Process:
   Arguments:
     SQL_command:
     - UPDATE `InstallExecuteSequence` SET `InstallExecuteSequence`.`Condition`='Not Installed And (UT_FRB Or UT_FRS)' WHERE `InstallExecuteSequence`.`Action`='OlderOverNewerAbort'
-    - UPDATE `Registry` SET `Registry`.`Value`='%ASver%' WHERE `Registry`.`Registry`='RegHKLM2'
-    - UPDATE `Registry` SET `Registry`.`Value`='%ASver%' WHERE `Registry`.`Registry`='Reg64HKLM2'
-    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='AdobeReaderDC_%version%_Deu.msi', `MoveFile`.`DestName`='AdobeReaderDC_%version%_Deu.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroRdrDC1501720050_de_DE.msi'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%version%_Deu.msi'
+    - UPDATE `Registry` SET `Registry`.`Value`='%ver_major%,%ver_majorminor%,%ver_minor%' WHERE `Registry`.`Registry`='RegHKLM2'
+    - UPDATE `Registry` SET `Registry`.`Value`='%ver_major%,%ver_majorminor%,%ver_minor%' WHERE `Registry`.`Registry`='Reg64HKLM2'
+    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi', `MoveFile`.`DestName`='AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroRdrDC1501720050_de_DE.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate the Adobe Reader icons for BMS Kiosk.
@@ -106,7 +106,7 @@ Process:
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAMELONG%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%version%_Deu.msi'
+    source_app: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi'
     msi_icon_name: 'SC_Reader.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAMELONG%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAMELONG%.png'
@@ -120,6 +120,6 @@ Process:
       /j: 'Acrobat Reader DC'
       /o: Altered and hardened version for corporate use. %us_date% by AutoPkg
       /t: 'Acrobat Reader DC'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%version%_Deu.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AdobeReaderDC_%ver_major%.%ver_majorminor%.%ver_minor%_Deu.msi'
 
 - Processor: EndOfCheckPhase

--- a/Adobe/AdobeReaderDC-Win64.BMS.recipe.yaml
+++ b/Adobe/AdobeReaderDC-Win64.BMS.recipe.yaml
@@ -21,7 +21,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -83,9 +83,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Adobe/AdobeReaderDC-Win64.build.recipe.yaml
+++ b/Adobe/AdobeReaderDC-Win64.build.recipe.yaml
@@ -18,40 +18,35 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-x64.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-x64.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the AdobeReaderDC-Win64 installer
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-x64.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-x64.exe'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -62,16 +57,16 @@ Process:
     cab_dir: adm
     cab_file: Data1
     embed_cab: 'True'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%\AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%\AcroPro.msi'
     msp_path: sourceunzipped\%NAME%\AcroRdrDCx64Upd%version_string%.msp
     new_msi_path: adm\AcroRdrDCx64Upd%version_string%.msi
     new_packcode: 'True'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
+    pkg_dir_abs: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/AcrobatGUIDPatcher
   Arguments:
     base_GUID: '{AC76BA86-1031-1033-7760-BC15014EA700}'
-    new_ver: '%version%'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%'
     old_hex_ver: 15014EA7
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -81,43 +76,43 @@ Process:
     - UPDATE `Property` SET `Property`.`Value`='%newGUID%' WHERE `Property`.`Property`='ProductCode'
     - UPDATE `Property` SET `Property`.`Value`='Adobe Acrobat Reader DC DE-EN' WHERE `Property`.`Property`='ProductName'
     - UPDATE `Component` SET `Component`.`Condition`='CHROMEPLUGIN' WHERE `Component`.`Component`='WCChromeNativeMessagingHost'
-    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroRdrDCx64Upd%version_string%.msi'
+    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\AcroRdrDCx64Upd%version_string%.msi'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\adm\AcroRdrDCx64Upd%version_string%.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\AcroRdrDCx64Upd%version_string%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Applies the transforms to the AdobeReaderDC.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
     mst_paths:
-    - '%BUILD_DIR%\%pkg_dir%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
-    - '%BUILD_DIR%\%pkg_dir%\helpers\JavaScript_Disable_byAutoPkg.mst'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Enterprise_Lockdown_byAutoPkg.mst'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\JavaScript_Disable_byAutoPkg.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
-    - UPDATE `Registry` SET `Registry`.`Value`='%ASver%' WHERE `Registry`.`Registry`='RegHKLM2'
-    - UPDATE `Registry` SET `Registry`.`Value`='%ASver%' WHERE `Registry`.`Registry`='Reg64HKLM2'
-    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%version%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Registry` SET `Registry`.`Value`='%ver_major%,%ver_majorminor%,%ver_minor%' WHERE `Registry`.`Registry`='RegHKLM2'
+    - UPDATE `Registry` SET `Registry`.`Value`='%ver_major%,%ver_majorminor%,%ver_minor%' WHERE `Registry`.`Registry`='Reg64HKLM2'
+    - UPDATE `MoveFile` SET `MoveFile`.`SourceName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi', `MoveFile`.`DestName`='%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi' WHERE `MoveFile`.`FileKey`='CacheSetupFiles_AcroPro.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\adm\Program Files 64\Adobe\Acrobat DC\Acrobat\Acrobat.exe'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\adm\Program Files 64\Adobe\Acrobat DC\Acrobat\Acrobat.exe'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
     #msi_icon_name: '_SC_Acrobat.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -128,9 +123,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adobe Reader DC %version%
+      /j: Adobe Reader DC %ver_major%.%ver_majorminor%.%ver_minor%
       /o: Altered and hardened version for corporate use. %us_date% by AutoPkg
-      /t: Adobe Reader DC %version%
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adobe Reader DC %ver_major%.%ver_majorminor%.%ver_minor%
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Adobe/AdobeReaderDCMSI-Win.download.recipe.yaml
+++ b/Adobe/AdobeReaderDCMSI-Win.download.recipe.yaml
@@ -27,16 +27,6 @@ Process:
     re_pattern: /AcroRdrDCUpd(?P<version_string>(?P<ver_major>[0-9]{2})(?P<ver_majorminor>[0-9]{3})(?P<ver_minor>[0-9]{5}))\.msp
     url: https://www.adobe.com/devnet-docs/acrobatetk/tools/ReleaseNotesDC/%match%
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%.%ver_majorminor%.%ver_minor%'
-    rename_var: version
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%,%ver_majorminor%,%ver_minor%'
-    rename_var: ASver
-
 - Processor: URLDownloader
   Arguments:
     CHECK_FILESIZE_ONLY: 'False'

--- a/Adobe/AdobeReaderDCMSI-Win64.download.recipe.yaml
+++ b/Adobe/AdobeReaderDCMSI-Win64.download.recipe.yaml
@@ -28,16 +28,6 @@ Process:
     url: https://www.adobe.com/devnet-docs/acrobatetk/tools/ReleaseNotesDC/%match%
     #url: https://www.adobe.com/devnet-docs/acrobatetk/tools/ReleaseNotesDC/%sub_string%
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%.%ver_majorminor%.%ver_minor%'
-    rename_var: version
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%,%ver_majorminor%,%ver_minor%'
-    rename_var: ASver
-
 - Processor: URLDownloader
   Arguments:
     CHECK_FILESIZE_ONLY: 'False'

--- a/Anaconda/Anaconda-Win64.build.recipe.yaml
+++ b/Anaconda/Anaconda-Win64.build.recipe.yaml
@@ -23,24 +23,19 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the Anaconda install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the Anaconda icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -55,12 +50,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Apple/iTunes-Win64.build.recipe.yaml
+++ b/Apple/iTunes-Win64.build.recipe.yaml
@@ -23,82 +23,67 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-%version%-%PLATFORM%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-%version%-%PLATFORM%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-%version%-%PLATFORM%.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
-    extract_file: '@%BUILD_DIR%\%pkg_dir%\helpers\iTunes%PF_SHORT%-files.txt'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-%version%-%PLATFORM%.exe'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped'
+    extract_file: '@%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\iTunes%PF_SHORT%-files.txt'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Comment: Get the version from Bonjour%PF_SHORT%.msi into msi_value
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Bonjour%PF_SHORT%.msi'
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: BJ_version
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Bonjour%PF_SHORT%.msi'
 
 - Processor: Copier
   Comment: Copy the Bonjour64.msi to the release folder
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\Bonjour%PF_SHORT%_%BJ_version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\Bonjour%PF_SHORT%_%msi_value%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Bonjour%PF_SHORT%.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Bonjour%PF_SHORT%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Comment: Get the version from AppleMobileDeviceSupport%PF_SHORT%.msi into msi_value
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\AppleMobileDeviceSupport%PF_SHORT%.msi'
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: AMDS_version
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\AppleMobileDeviceSupport%PF_SHORT%.msi'
 
 - Processor: Copier
   Comment: Copy the AppleMobileDeviceSupport64.msi to the release folder
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\AppleMobileDeviceSupport%PF_SHORT%_%AMDS_version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AppleMobileDeviceSupport%PF_SHORT%_%msi_value%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\AppleMobileDeviceSupport%PF_SHORT%.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\AppleMobileDeviceSupport%PF_SHORT%.msi'
 
 - Processor: Copier
   Comment: Copy the iTunes.msi to the release folder
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%%PF_SHORT%.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%%PF_SHORT%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Comment: Get the version from iTunes64.msi into msi_value
   Arguments:
     SQL_command: SELECT `File`.`File` FROM `File`, `Component`, `Directory` WHERE `File`.`Component_` = `Component`.`Component` AND `Directory`.`Directory` = `Component`.`Directory_` AND `DefaultDir`='tajvqtga|de.lproj' AND `FileName`='License.rtf'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\iTunes%PF_SHORT%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\iTunes%PF_SHORT%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\iTunes%PF_SHORT%.msi'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\helpers'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\iTunes%PF_SHORT%.msi'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers'
     extract_file: '%msi_value%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/TextFileSearcher
   Comment: Searches the german License.rtf file in iTunes.msi for the EULA string
   Arguments:
-    file_to_open: '%BUILD_DIR%\%pkg_dir%\helpers\%msi_value%'
+    file_to_open: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\%msi_value%'
     re_pattern: \\cf2.(?P<eulastring>[EA]{2}[0-9]{4})\\cf2
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
@@ -107,8 +92,8 @@ Process:
   Comment: Applies the Settings-Transform to the iTunes.msi to the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\iTunes%PF_SHORT%-Settings.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\iTunes%PF_SHORT%-Settings.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Comment: Change a few settings in the iTunes MSI-file
@@ -117,8 +102,8 @@ Process:
     - UPDATE `Property` SET `Property`.`Value`='iTunes %version% ML' WHERE `Property`.`Property`='ProductName'
     - UPDATE `Registry` SET `Registry`.`Value`='%AS_ver%' WHERE `Registry`.`Registry`='RegHKLM2'
     - UPDATE `Registry` SET `Registry`.`Value`='%matchstring%' WHERE `Registry`.`Registry`='RegHKLM7'
-    - UPDATE `caPackage` SET `caPackage`.`FileName`='AppleMobileDeviceSupport%PF_SHORT%_%AMDS_version%%LANG_STRING%.msi' WHERE `caPackage`.`PackageKey`='AppleMobileDeviceSupport'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `caPackage` SET `caPackage`.`FileName`='AppleMobileDeviceSupport%PF_SHORT%_%msi_value%%LANG_STRING%.msi' WHERE `caPackage`.`PackageKey`='AppleMobileDeviceSupport'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
@@ -127,65 +112,65 @@ Process:
       /o: Version %version% for ETHZ ID. %us_date% by AutoPkg
       /p: x64;1033
       /t: iTunes x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIDbWorker
   Comment: Extract language transforms from the iTunes MSI-file
   Arguments:
     mode: -w
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     workfile: '1031'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\helpers'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers'
 
 - Processor: Copier
   Comment: Make a copy from iTunes.msi to the helpers folder to apply the language transform
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\%NAME%%PF_STRING%_1031.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Apply the language transforms to the iTunes MSI copy
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\1031'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\%NAME%%PF_STRING%_1031.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\1031'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Comment: Get the product GUID from iTunes64.msi into msi_value
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Comment: Put the original product GUID into the transformed iTunes MSI-file
   Arguments:
     SQL_command:
     - UPDATE `Property` SET `Property`.`Value`='%msi_value%' WHERE `Property`.`Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\%NAME%%PF_STRING%_1031.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Generate a new 1031 language transform from the iTunes MSI-file and the copy
   Arguments:
     mode: -g
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
-    msi_path_new: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\1031'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path_new: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\%NAME%%PF_STRING%_1031.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\1031'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIDbWorker
   Comment: Delete the existing 1031 language transforms from the iTunes MSI-file
   Arguments:
     mode: -j
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     workfile: '1031'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIDbWorker
   Comment: Embed the altered 1031 language transforms into the iTunes MSI-file
   Arguments:
     mode: -r
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     workfile: '1031'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Comment: Change a few settings in the Bonjour64 MSI-file
@@ -193,16 +178,16 @@ Process:
     SQL_command:
     - UPDATE `ServiceInstall` SET `ServiceInstall`.`StartType`=4 WHERE `ServiceInstall`.`ServiceInstall`='Bonjour_Service'
     - UPDATE `ServiceControl` SET `ServiceControl`.`Event`=162 WHERE `ServiceControl`.`ServiceControl`='Bonjour_Service'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\Bonjour%PF_SHORT%_%BJ_version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\Bonjour%PF_SHORT%_%msi_value%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Bonjour x64 %BJ_version% ML
-      /o: Version %BJ_version% for ETHZ ID. %us_date% by AutoPkg
+      /j: Bonjour x64 %msi_value% ML
+      /o: Version %msi_value% for ETHZ ID. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Bonjour x64 %BJ_version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\Bonjour%PF_SHORT%_%BJ_version%%LANG_STRING%.msi'
+      /t: Bonjour x64 %msi_value% ML
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\Bonjour%PF_SHORT%_%msi_value%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Comment: Change a few settings in the AppleMobileDeviceSupport64 MSI-file
@@ -211,40 +196,40 @@ Process:
     - INSERT INTO `Property` (`Property`.`Property`,`Property`.`Value`) VALUES ('REBOOT','ReallySuppress')
     - UPDATE `InstallExecuteSequence` SET `InstallExecuteSequence`.`Sequence`='1450' WHERE `InstallExecuteSequence`.`Action`='RemoveExistingProducts'
     - DELETE FROM `LaunchCondition` WHERE `LaunchCondition`.`Condition`='NOT BNEWERPRODUCTISINSTALLED'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AppleMobileDeviceSupport%PF_SHORT%_%AMDS_version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AppleMobileDeviceSupport%PF_SHORT%_%msi_value%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Apple Mobile Device Support x64 %AMDS_version% ML
-      /o: Version %AMDS_version% for ETHZ ID. %us_date% by AutoPkg
+      /j: Apple Mobile Device Support x64 %msi_value% ML
+      /o: Version %msi_value% for ETHZ ID. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Apple Mobile Device Support x64 %AMDS_version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\AppleMobileDeviceSupport%PF_SHORT%_%AMDS_version%%LANG_STRING%.msi'
+      /t: Apple Mobile Device Support x64 %msi_value% ML
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\AppleMobileDeviceSupport%PF_SHORT%_%msi_value%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    # source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     msi_icon_name: 'iTunes.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/Arduino/ArduinoIDE-Win64.build.recipe.yaml
+++ b/Arduino/ArduinoIDE-Win64.build.recipe.yaml
@@ -35,15 +35,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the ArduinoIDE installer file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -52,32 +47,32 @@ Process:
   Arguments:
     SQL_command:
     - DELETE FROM `Shortcut` WHERE `Shortcut`.`Shortcut`='desktopShortcut'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/Artifex/Ghostscript-Win64.BMS.recipe.yaml
+++ b/Artifex/Ghostscript-Win64.BMS.recipe.yaml
@@ -70,8 +70,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.exe|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.exe|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Artifex/Ghostscript-Win64.build.recipe.yaml
+++ b/Artifex/Ghostscript-Win64.build.recipe.yaml
@@ -42,57 +42,52 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Eclipse installer files to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\gs\gs%build_ver%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\gs%build_ver%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\gs\gs%build_ver%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\gs%build_ver%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\gs-remove-files.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\gs%build_ver%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\delete'
+    file_list: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\gs-remove-files.txt'
+    source_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\gs%build_ver%'
+    target_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\delete'
 
 - Processor: PathDeleter
   Comment: Delete unnesessary folders from the Ghostscript installer directory
   Arguments:
     path_list:
-    - '%BUILD_DIR%\%pkg_dir%\wixproject\gs%build_ver%\$PLUGINSDIR'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\gs%build_ver%\$PLUGINSDIR'
 
 # - Processor: FileMover
   # Comment: Rename the Ghostscript installer folder to the build dir
   # Arguments:
-    # target: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
-    # source: '%BUILD_DIR%\%pkg_dir%\wixproject\eclipse\'
+    # target: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\'
+    # source: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\eclipse\'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\ghostscript_256.ico'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\ghostscript_256.ico'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -101,10 +96,10 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the Ghostscript res file
   Arguments:
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\gs\gs%build_ver%\bin\gswin64.exe'
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\bin\gswin64.exe'
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\gs%build_ver%\bin\gswin64.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    # exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\gs\gs%build_ver%\bin\gswin64.exe'
+    # exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\bin\gswin64.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\gs%build_ver%\bin\gswin64.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -112,9 +107,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Ghostscript
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -123,20 +118,20 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\version.wxi'
     # template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -157,8 +152,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Eclipse MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\gs%build_ver%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\gs%build_ver%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
 
     build_target: WIX

--- a/Audacity/Audacity-Win64.build.recipe.yaml
+++ b/Audacity/Audacity-Win64.build.recipe.yaml
@@ -26,38 +26,33 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/InnoEditor
   Comment: Extract the Audacity installer
   Arguments:
     inno_path: '%PATHNAME1%'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     ignore_errors: False
 
 - Processor: Copier
   Comment: Copy the Audacity installer files to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\**'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\{app}\**'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/InnoEditor
   Comment: Extract the FFMPEG installer
   Arguments:
     inno_path: '%pathname%'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\ffmpeg\'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\ffmpeg\'
     ignore_errors: False
 
 # - Processor: Copier
   # Comment: Copy the Audacity FFMPEG files to the build dir
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\ffmpeg\{app}\**'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\ffmpeg\{app}\**'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: build the filelist for the FFMPEG files to copy
@@ -66,35 +61,35 @@ Process:
     - /C
     - dir
     - /b
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\ffmpeg\{app}'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\ffmpeg\{app}'
     - '>'
-    - '%BUILD_DIR%\%pkg_dir%\helpers\ffmpeg-move-files.txt'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\ffmpeg-move-files.txt'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Comment: Move the FFMPEG files to the build dir
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\ffmpeg-move-files.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\ffmpeg\{app}'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
+    file_list: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\ffmpeg-move-files.txt'
+    source_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\ffmpeg\{app}'
+    target_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
 
 - Processor: PathDeleter
   Comment: Delete Firsttime.ini from the Audacity installer directory
   Arguments:
     path_list:
-    - '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\FirstTime.ini'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\FirstTime.ini'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\Audacity.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\{app}\Audacity.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -103,8 +98,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the Audacity res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\Audacity.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\{app}\Audacity.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -112,9 +107,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Audacity
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -123,20 +118,20 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\version.wxi'
     # template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -160,7 +155,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Audacity MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX

--- a/Autodesk/DWGTrueview-Win64.BMS.recipe.yaml
+++ b/Autodesk/DWGTrueview-Win64.BMS.recipe.yaml
@@ -27,61 +27,9 @@ Process:
       repl: _
 
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: |
-      <?xml version="1.0" encoding="ISO-8859-1"?>
-      <baramundiDeployScript Version="2420" LastChange="ddaatteettiimmee">
-      <META>
-      <INFO Vendor="" Name="" Version="" Author="Autopkg" Comment=""/>
-      <STATICVARS LoadInstallIni="1">
-      <BMSVars></BMSVars>
-      </STATICVARS>
-      </META>
-      <ACTIONS>
-      <ACTION type="SetX64Mode" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <MODE>1</MODE>
-      </DATA>
-      </ACTION>
-      <ACTION type="Comment" level="0" breakpoint="0" ignore_error="0" comment="1" is_included="0" logging_enabled="1">
-      <DATA>
-      <VALUE>Write UnNamed.json file to each user profile</VALUE>
-      </DATA>
-      </ACTION>
-      <ACTION type="CreateFile" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-                                                             
-      <FILENAME>{%AppData%}&#92;Roaming&#92;Autodesk&#92;ADPSDK&#92;UserConsent&#92;UnNamed.json</FILENAME>
-      <ENCODING>1</ENCODING>
-      <CONTENT>{
-      &quot;preferences&quot;: [
-        {
-            &quot;consentId&quot;: &quot;ADSK_PUD_CONTRACTUAL_NECESSITY_DESKTOP&quot;,
-            &quot;optIn&quot;: false
-        },
-        {
-            &quot;consentId&quot;: &quot;ADSK_PUD_OPTIMIZATION_IMPROVEMENT_DESKTOP&quot;,
-            &quot;optIn&quot;: false
-        },
-        {
-            &quot;consentId&quot;: &quot;ADSK_PUD_GO_TO_MARKET_DESKTOP&quot;,
-            &quot;optIn&quot;: false
-        }
-      ],
-      &quot;userActionRequired&quot;: false,
-      &quot;userId&quot;: &quot;UnNamed&quot;
-      }</CONTENT>
-      <OPTIONS>1</OPTIONS>
-      </DATA>
-      </ACTION>
-      </ACTIONS>
-      </baramundiDeployScript>
-    rename_var: bds_content
-
 # - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   # Arguments:
-    # input_string: '%bds_content%'
+    # input_string: '|'
     # pattern_replace:
     # - pattern: SSuubbssttiittuuttee
       # repl: '%DIP_NAME%&#92;%parsed_string%&#92;%DIP_SUBDIR%'
@@ -89,7 +37,7 @@ Process:
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
     #input_string: '%parsed_string%'
-    input_string: '%bds_content%'
+    input_string: '|'
     pattern_replace:
     - pattern: ddaatteettiimmee
       repl: '%us_date% %time%'
@@ -98,7 +46,7 @@ Process:
   Comment: Generate the install.bds in the release dir.
   Arguments:
     file_content: '%parsed_string%'
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%_Usr.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%_Usr.bds'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -173,9 +121,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Autodesk/DWGTrueview-Win64.build.recipe.yaml
+++ b/Autodesk/DWGTrueview-Win64.build.recipe.yaml
@@ -59,11 +59,6 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: URLTextSearcher
   Arguments:
     re_pattern: '<Upi2>{(?P<UPI2>[0-9a-fA-F\-]{36})}</Upi2>'
@@ -78,19 +73,19 @@ Process:
   Arguments:
     overwrite: 'true'
     source_path: '%EXE_DL%'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
 
 - Processor: Copier
   Arguments:
     overwrite: 'true'
     source_path: '%pathname%'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.7z'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.7z'
 
 - Processor: Copier
   Arguments:
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\helpers\UnNamed.json'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\UnNamed.json'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\UnNamed.json'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\UnNamed.json'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   # Arguments:
@@ -119,7 +114,7 @@ Process:
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from DWG TrueView
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -134,13 +129,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Bitwarden/Bitwarden-Desktop-Win64.build.recipe.yaml
+++ b/Bitwarden/Bitwarden-Desktop-Win64.build.recipe.yaml
@@ -40,23 +40,18 @@ Process:
     ver_fields: '3'
     create_AS_ver: 'true'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Bitwarden-Desktop installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Bitwarden-Desktop NSIS installer to the sourceunzipped dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAME%\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -64,17 +59,17 @@ Process:
 - Processor: PathDeleter
   Comment: Delete the app-update.yml file. This disables the Auto Update.
   Arguments:
-    path_list: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\resources\app-update.yml'
+    path_list: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAME%\resources\app-update.yml'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAME%\%NAME%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -83,8 +78,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the Bitwarden-Desktop res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAME%\%NAME%.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -92,9 +87,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Bitwarden-Desktop
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -103,20 +98,20 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAMELONG%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAMELONG%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAMELONG%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAMELONG%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\version.wxi'
     # template_file: None
     new_settings:
     - define: 'version="%msiversion%"'
@@ -137,8 +132,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Bitwarden-Desktop MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%msiversion%;versionlong=%version%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAME%;version=%msiversion%;versionlong=%version%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     #;"ASVersion=%AS_ver%"
     build_target: WIX

--- a/Blender/Blender-Win64.BMS.recipe.yaml
+++ b/Blender/Blender-Win64.BMS.recipe.yaml
@@ -17,7 +17,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -71,8 +71,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
  
 - Processor: EndOfCheckPhase

--- a/Blender/Blender-Win64.build.recipe.yaml
+++ b/Blender/Blender-Win64.build.recipe.yaml
@@ -22,15 +22,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -39,17 +34,17 @@ Process:
   Arguments:
     SQL_command:
     - UPDATE `Component` SET `Component`.`Condition`='DESKTOPSC=1' WHERE `Component`.`Component`='CM_SHORTCUT_DESKTOP_Blender'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -57,14 +52,14 @@ Process:
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/Claris/FileMakerPro-Win64.BMS.recipe.yaml
+++ b/Claris/FileMakerPro-Win64.BMS.recipe.yaml
@@ -29,14 +29,14 @@ Process:
 - Processor: Copier
   Comment: Copy the FileMaker license file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\LicenseCert.fmcert'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\LicenseCert.fmcert'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\LicenseCert.fmcert'
     
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%ALTNAME% %MAJOR_VERSION%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%ALTNAME% %MAJOR_VERSION%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -74,7 +74,7 @@ Process:
       </ACTION>
       </ACTIONS>
       </baramundiDeployScript>
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\i_FM%MAJOR_VERSION%FW.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\i_FM%MAJOR_VERSION%FW.bds'
 
 - Processor: FileCreator
   Comment: Generate the firewall uninstall.bds in the release dir.
@@ -105,7 +105,7 @@ Process:
       </ACTION>
       </ACTIONS>
       </baramundiDeployScript>
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\u_FM%MAJOR_VERSION%FW.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\u_FM%MAJOR_VERSION%FW.bds'
     
 - Processor: com.github.NickETH.recipes.SharedProcessors/BMSImporter
   Comment: Import the Application into Baramundi (BMS) QSS
@@ -160,9 +160,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Claris/FileMakerPro-Win64.build.recipe.yaml
+++ b/Claris/FileMakerPro-Win64.build.recipe.yaml
@@ -25,11 +25,6 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.jazzace.processors/TextSearcher
   Arguments:
     text_in: '%build_ver%'
@@ -45,44 +40,44 @@ Process:
 - Processor: Copier
   Comment: Copy the FileMaker installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the FileMaker exe installer wrapper
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: FileFinder
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%ALTNAME%*'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%ALTNAME%*'
 
 - Processor: Copier
   Comment: Copy the FileMaker installer files to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\'
     overwrite: 'true'
-    #source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%ALTNAME% %short_version%\Files\'
+    #source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%ALTNAME% %short_version%\Files\'
     source_path: '%found_filename%\Files\'
 
 - Processor: Copier
   Comment: Make a copy from FileMaker MSI to the helpers folder to apply the language transform and additional properties
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\%NAME%%PF_STRING%_1031.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\release\%ALTNAME% %MAJOR_VERSION%.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%ALTNAME% %MAJOR_VERSION%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Apply the language transform to the FileMaker MSI copy
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\release\1031.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\%NAME%%PF_STRING%_1031.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\1031.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Comment: Change a few settings in the FileMaker MSI-file
@@ -102,27 +97,27 @@ Process:
     - DELETE FROM `LaunchCondition` WHERE `LaunchCondition`.`Condition`='ACTIONPROPERTY Or (LanguagePackInstaller=0) Or Installed'
     - INSERT INTO `Directory` (`Directory`.`Directory`,`Directory`.`Directory_Parent`,`Directory`.`DefaultDir`) VALUES ('SHORTCUTDIR','ProgramMenuFolder','Filemaker')
     - UPDATE `Shortcut` SET `Shortcut`.`Directory_`='SHORTCUTDIR', `Shortcut`.`Name`='FILEMA~4|FileMaker Pro %MAJOR_VERSION%' WHERE `Shortcut`.`Shortcut`='FileMakerDeveloper'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\%NAME%%PF_STRING%_1031.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Generate a new 1031 language transform from the FileMaker MSI-file and the copy
   Arguments:
     mode: -g
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%ALTNAME% %MAJOR_VERSION%.msi'
-    msi_path_new: '%BUILD_DIR%\%pkg_dir%\helpers\%NAME%%PF_STRING%_1031.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\release\p%MAJOR_VERSION%_1031.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%ALTNAME% %MAJOR_VERSION%.msi'
+    msi_path_new: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\%NAME%%PF_STRING%_1031.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\p%MAJOR_VERSION%_1031.mst'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%ALTNAME% %MAJOR_VERSION%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%ALTNAME% %MAJOR_VERSION%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -130,12 +125,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Clarivate/Endnote-Win.BMS.recipe.yaml
+++ b/Clarivate/Endnote-Win.BMS.recipe.yaml
@@ -19,7 +19,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -33,21 +33,21 @@ Process:
   Arguments:
     cmdline_args:
     - /a
-    - '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
-    - TARGETDIR=%BUILD_DIR%\%pkg_dir%\adm  
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    - TARGETDIR=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\adm  
     - USERNAME="%LIC_USR%"
     - PIDKEY=%LIC_KEY%
     - VLAccept=1
     - /qn
     exe_file: msiexec.exe
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\adm'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\adm'
 
 - Processor: Copier
   Comment: Copy the Endnote License file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\License.dat'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\License.dat'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\adm\License.dat'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\adm\License.dat'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/BMSImporter
   Comment: Import the Application into Baramundi (BMS)
@@ -93,8 +93,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Clarivate/Endnote-Win.build.recipe.yaml
+++ b/Clarivate/Endnote-Win.build.recipe.yaml
@@ -36,15 +36,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Endnote installer file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -56,7 +51,7 @@ Process:
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 1
     # composite_padding: 20
     # composite_position: ul
@@ -71,16 +66,16 @@ Process:
 
 - Processor: URLDownloader
   Arguments:
-    #filename: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%CF_NAME%-%MAJOR_VERSION%.zip'
+    #filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%CF_NAME%-%MAJOR_VERSION%.zip'
     filename: '%CF_NAME%-%MAJOR_VERSION%.zip'
     url: '%CONN_URL%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the connection files
   Arguments:
-    #exe_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%CF_NAME%-%MAJOR_VERSION%.zip'
+    #exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%CF_NAME%-%MAJOR_VERSION%.zip'
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%CF_NAME%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%CF_NAME%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'False'
@@ -88,14 +83,14 @@ Process:
 - Processor: URLDownloader
   Comment: Get the connection file for the Swiss Universities
   Arguments:
-    #filename: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%CF_NAME%\Swisscovery.enz'
+    #filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%CF_NAME%\Swisscovery.enz'
     filename: 'Swisscovery.enz'
     url: '%SWICOV_URL%'
 
 - Processor: Copier
   Comment: Copy the Swisscovery connection file for the to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%CF_NAME%\Swisscovery.enz'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%CF_NAME%\Swisscovery.enz'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -109,22 +104,22 @@ Process:
     - -t7z
     # - -v1900m
     - -mx9
-    - '%BUILD_DIR%\%pkg_dir%\release\%CF_NAME%.exe'
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%CF_NAME%\*.*'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%CF_NAME%.exe'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%CF_NAME%\*.*'
     exe_file: '%SZIP_PATH%'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
 
 # - Processor: Copier
   # Comment: Copy the Endnote License file to the release dir
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\License.dat'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\License.dat'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\helpers\License.dat'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\License.dat'
  
 # - Processor: Copier
   # Comment: Copy the Endnote installer file to the build dir
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%-%MAJOR_VERSION%.msp'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\%NAME%-%MAJOR_VERSION%.msp'
     # overwrite: 'true'
     # source_path: '%pathname%'
 
@@ -140,19 +135,19 @@ Process:
     # msp_path: 'sourceunzipped\%NAME%-%MAJOR_VERSION%.msp'
     # new_msi_path: adm\%NAME%%PF_STRING%_%build_ver%_ML.msi
     # new_packcode: 'True'
-    # pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
+    # pkg_dir_abs: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Dell/CommandUpdate-Win64.BMS.recipe.yaml
+++ b/Dell/CommandUpdate-Win64.BMS.recipe.yaml
@@ -18,7 +18,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\release\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -72,9 +72,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\read\*-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase
 

--- a/Dell/CommandUpdate-Win64.build.recipe.yaml
+++ b/Dell/CommandUpdate-Win64.build.recipe.yaml
@@ -25,23 +25,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAMESHORT%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the CommandUpdate installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAMESHORT%_%PLATFORM%.exe'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAMESHORT%_%PLATFORM%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the exe-installer from the Universal package
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAMESHORT%_%PLATFORM%.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAMESHORT%_%PLATFORM%.exe'
+    extract_dir: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\sourceunzipped'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'False'
@@ -49,28 +44,28 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: Extract the MSI-installer from the EXE package
   Arguments:
-    exe_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\DellCommandUpdateApp_Setup.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
-    cmdline_args: '/s /x /b"%BUILD_DIR%\%pkg_dir%\sourceunzipped" /v"/qn"'
+    exe_file: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\sourceunzipped\DellCommandUpdateApp_Setup.exe'
+    exe_folder: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\sourceunzipped'
+    cmdline_args: '/s /x /b"%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\sourceunzipped" /v"/qn"'
     run_elevated: 'True'
 
 - Processor: Copier
   Comment: Copy the CommandUpdate installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\release\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\DellCommandUpdateApp.msi'
+    source_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\sourceunzipped\DellCommandUpdateApp.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\read\create-log-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\read\readme-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'

--- a/Dropbox/DropboxClient-Win.build.recipe.yaml
+++ b/Dropbox/DropboxClient-Win.build.recipe.yaml
@@ -41,47 +41,42 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Dropbox-Innner-installer.exe'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Dropbox-Innner-installer.exe'
     overwrite: 'true'
     source_path: '%found_filename%'
 
 - Processor: Copier
   Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Dropbox-Innner-installer.exe'
+    # destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Dropbox-Innner-installer.exe'
     overwrite: 'true'
     source_path: '%found_filename%'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\DropboxOfflineInstaller-%version%.exe'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\DropboxOfflineInstaller-%version%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\release\'
+    exe_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    extract_dir: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\'
     extract_file: $0\DropboxUninstaller.exe
     preserve_paths: 'False'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from Telegraf
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    source_app: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -89,13 +84,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\Create-log-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\read\Create-log-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Dropbox/DropboxClient-Win64.build.recipe.yaml
+++ b/Dropbox/DropboxClient-Win64.build.recipe.yaml
@@ -42,53 +42,48 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Dropbox-Innner-installer.exe'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Dropbox-Innner-installer.exe'
     overwrite: 'true'
     source_path: '%found_filename%'
 
 - Processor: Copier
   Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Dropbox-Innner-installer.exe'
+    # destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Dropbox-Innner-installer.exe'
     overwrite: 'true'
     source_path: '%found_filename%'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
 
 # - Processor: FileMover
   # Arguments:
     # overwrite: 'true'
     # source: '%found_filename%'
-    # target: '%BUILD_DIR%\%pkg_dir%\release\\NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.exe'
+    # target: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\\NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.exe'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\DropboxOfflineInstaller-%version%.exe'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\DropboxOfflineInstaller-%version%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\release\'
+    exe_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    extract_dir: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\'
     extract_file: $0\DropboxUninstaller.exe
     preserve_paths: 'False'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from Telegraf
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    source_app: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -96,13 +91,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\Create-log-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\read\Create-log-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAMESHORT%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Eclipse/AdoptiumIcedTeaWeb-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumIcedTeaWeb-Win64.build.recipe.yaml
@@ -20,31 +20,26 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read
-    org_ver: '%version%'
+    org_ver: '%msi_value%'
     pkg_dir: '%VENDOR%_%NAME%%PF_STRING%_::VVeerrssiioonn::_ML'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -53,9 +48,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium %NAME% %PLATFORM% %version% ML
-      /o: Version %version%. %us_date% by AutoPkg
-      /t: Adoptium %NAME% %PLATFORM% %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.msi'
+      /j: Adoptium %NAME% %PLATFORM% %msi_value% ML
+      /o: Version %msi_value%. %us_date% by AutoPkg
+      /t: Adoptium %NAME% %PLATFORM% %msi_value% ML
+    msi_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%msi_value%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumIcedTeaWeb-Win64.download.recipe.yaml
+++ b/Eclipse/AdoptiumIcedTeaWeb-Win64.download.recipe.yaml
@@ -23,9 +23,4 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJDK11-Win.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJDK11-Win.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JDK_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JDK_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium Java DK Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium Java DK Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJDK11-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJDK11-Win64.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JDK_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JDK_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium Java DK Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium Java DK Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJDK17-Win64.BMS.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJDK17-Win64.BMS.recipe.yaml
@@ -27,7 +27,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%version%_ML\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -80,9 +80,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%version%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%version%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%version%_ML\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJDK17-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJDK17-Win64.build.recipe.yaml
@@ -28,61 +28,56 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JDK_Hotspot_64_::VVeerrssiioonn::_ML
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JDK_Hotspot_64_%version%_ML
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\read\create-log-%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.([0-9]+\.)[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\read\readme-%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.([0-9]+\.)[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-JDK_%FEATUREVER%-x64.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\helpers\Zulu-JFX-JDK_%FEATUREVER%-x64.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -92,37 +87,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX_64_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\JavaFX_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML'
+    temp_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',11,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium Java DK Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium Java DK Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+      /t: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJDK8-Win.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJDK8-Win.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JDK_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JDK_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium Java DK Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium Java DK Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJDK8-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJDK8-Win64.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JDK_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JDK_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium Java DK Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium Java DK Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium Java DK Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JDK_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJDKMSI-Win.download.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJDKMSI-Win.download.recipe.yaml
@@ -22,16 +22,6 @@ Process:
     - DOTALL
     url: https://api.adoptium.net/v3/assets/latest/%FEATUREVER%/hotspot?vendor=adoptium
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
-    rename_var: version
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%%ver_majorminor%%ver_minor%%ver_build%'
-    rename_var: version_string
-
 - Processor: URLTextSearcher
   Arguments:
     curl_opts:
@@ -45,16 +35,6 @@ Process:
     #re_pattern: '"(?P<zuludlfile>(?P<zuludldir>zulu.+-ca-fx-%PRODUCT%%ver_major%.%ver_majorminor%.%ver_minor%-win_%ZULUPLATFORM%).zip)"'
     #url: https://cdn.azul.com/zulu/bin
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%match%'
-    rename_var: zululink
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%,%ver_majorminor%,%ver_minor%'
-    rename_var: ASver
-
 - Processor: URLDownloader
   Arguments:
     CHECK_FILESIZE_ONLY: 'False'
@@ -66,16 +46,11 @@ Process:
     expected_subject: CN="Eclipse.org Foundation, Inc.", O="Eclipse.org Foundation, Inc.", L=Ottawa, S=Ontario, C=CA
     input_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%pathname%'
-    rename_var: path_msi
-
 - Processor: URLDownloader
   Arguments:
     CHECK_FILESIZE_ONLY: 'False'
     filename: '%DOWNLOAD_FILE%_zulu_%PLATFORM%.zip'
-    url: '%zululink%'
+    url: '%match%'
 
 - Processor: StopProcessingIf
   Arguments:
@@ -83,7 +58,7 @@ Process:
 
 - Processor: FileCreator
   Arguments:
-    file_content: '%version%'
+    file_content: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     file_path: '%RECIPE_CACHE_DIR%\version.txt'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE11-Win.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE11-Win.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JRE_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JRE_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium JRE Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium JRE Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE11-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE11-Win64.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JRE_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JRE_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium JRE Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium JRE Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE17-Win64.BMS.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE17-Win64.BMS.recipe.yaml
@@ -27,7 +27,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -80,9 +80,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE17-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE17-Win64.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JRE_Hotspot_64_::VVeerrssiioonn::_ML
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JRE_Hotspot_64_%version%_ML
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\read\create-log-%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\read\readme-%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-JRE_%FEATUREVER%-x64.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\helpers\Zulu-JFX-JRE_%FEATUREVER%-x64.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX_64_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\JavaFX_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML'
+    temp_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium JRE Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium JRE Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+      /t: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE21-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE21-Win64.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JRE_Hotspot_64_::VVeerrssiioonn::_ML
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JRE_Hotspot_64_%version%_ML
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\read\create-log-%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\read\readme-%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-JRE_%FEATUREVER%-x64.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\helpers\Zulu-JFX-JRE_%FEATUREVER%-x64.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX_64_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject\JavaFX_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML'
+    temp_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium JRE Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium JRE Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%_64_%version%_ML.msi'
+      /t: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML\release\%FILENAME%_64_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE8-Win.BMS.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE8-Win.BMS.recipe.yaml
@@ -27,7 +27,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -84,9 +84,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE8-Win.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE8-Win.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JRE_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JRE_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,37 +88,37 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium JRE Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium JRE Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE8-Win64.BMS.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE8-Win64.BMS.recipe.yaml
@@ -27,7 +27,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -89,9 +89,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\*-%FILENAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/AdoptiumOpenJRE8-Win64.build.recipe.yaml
+++ b/Eclipse/AdoptiumOpenJRE8-Win64.build.recipe.yaml
@@ -28,62 +28,57 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\%ADDON_NAME%:wixproject\Resources:wixproject\Lang
-    org_ver: '%version%'
+    org_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     pkg_dir: Adoptium_JRE_Hotspot%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Adoptium_JRE_Hotspot%PF_STRING%_%version%%LANG_STRING%
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\create-log-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%FILENAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\read\readme-%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.txt'
+    new_ver: '%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%version%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%DOWNLOAD_FILE%_hotspot_%PLATFORM%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%path_msi%'
+    source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
+    destination_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%zuludlfile%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%zuludlfile%'
+    extract_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%zuludldir%'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%'
+    file_list: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\helpers\Zulu-JFX-%PRODUCT%_%FEATUREVER%-%PLATFORM%.txt'
+    source_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourceunzipped\%zuludldir%'
+    target_dir: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%'
 
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -93,39 +88,39 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the JFX MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\%ADDON_NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: FeatureJavaFX
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\JavaFX%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject\JavaFX%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('FeatureJavaFX','FeatureMain','JavaFX','Install JavaFX',%FEATUREVER%,2,'INSTALLDIR',8)
-    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %version% ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    - UPDATE `Property` SET `Property`.`Value`='Adoptium Java RE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML' WHERE `Property`.`Property`='ProductName'
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
     msi_icon_name: 'logo.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -136,10 +131,10 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Adoptium JRE Hotspot x64 %version% ML
-      /o: Version %version% with JavaFX. %us_date% by AutoPkg
+      /j: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+      /o: Version %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% with JavaFX. %us_date% by AutoPkg
       /p: x64;1033
-      /t: Adoptium JRE Hotspot x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%FILENAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+      /t: Adoptium JRE Hotspot x64 %ver_major%.%ver_majorminor%.%ver_minor%.%ver_build% ML
+    msi_path: '%BUILD_DIR%\Adoptium_JRE_Hotspot%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%\release\%FILENAME%%PF_STRING%_%ver_major%.%ver_majorminor%.%ver_minor%.%ver_build%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/Eclipse-Java-Win64.BMS.recipe.yaml
+++ b/Eclipse/Eclipse-Java-Win64.BMS.recipe.yaml
@@ -17,7 +17,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -70,9 +70,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Eclipse/Eclipse-Java-Win64.build.recipe.yaml
+++ b/Eclipse/Eclipse-Java-Win64.build.recipe.yaml
@@ -42,24 +42,19 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Eclipse installer files to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -67,19 +62,19 @@ Process:
 - Processor: FileMover
   Comment: Rename the Eclipse installer folder to the build dir
   Arguments:
-    target: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
-    source: '%BUILD_DIR%\%pkg_dir%\wixproject\eclipse\'
+    target: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\'
+    source: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\eclipse\'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\Eclipse-Java\eclipse.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Eclipse-Java\eclipse.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -88,8 +83,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the Eclipse res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\Eclipse-Java\eclipse.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Eclipse-Java\eclipse.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -97,9 +92,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Eclipse-Java
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -108,20 +103,20 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\version.wxi'
     # template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -142,8 +137,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Eclipse MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
 
     build_target: WIX

--- a/Element/Element-Win64.BMS.recipe.yaml
+++ b/Element/Element-Win64.BMS.recipe.yaml
@@ -18,7 +18,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -71,8 +71,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Element/Element-Win64.build.recipe.yaml
+++ b/Element/Element-Win64.build.recipe.yaml
@@ -27,33 +27,28 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Element installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourcepkt\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\'
     extract_file: element-desktop-*-full.nupkg
 
 - Processor: FileFinder
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourcepkt\element-desktop-*-full.nupkg'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\element-desktop-*-full.nupkg'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
     exe_path: '%found_filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -61,20 +56,20 @@ Process:
 - Processor: Copier
   Comment: Copy the Element installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\Element\'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Element\'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\lib\net45\'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\lib\net45\'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -82,27 +77,27 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Element MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Element.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;ElementDir=%BUILD_DIR%\%pkg_dir%\wixproject\Element;version=%version%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Element.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;ElementDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Element;version=%version%
     build_target: WIX

--- a/Enpass/Enpass-Win.build.recipe.yaml
+++ b/Enpass/Enpass-Win.build.recipe.yaml
@@ -22,11 +22,6 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: run the SafeExamBrowser setup to extract the MSI file to the unzipped dir
   Arguments:
@@ -34,21 +29,21 @@ Process:
     - '%pathname%'
     - ''
     - -x
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped"'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped"'
     exe_file: '%DTF_PATH%\..\bin\dark.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourcepkt'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt'
 
 - Processor: FileFinder
   Comment: Get the full path to the extracted MSI file
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\*\*.msi'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\*\*.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the Enpass install msi file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%found_filename%'
 
@@ -57,30 +52,30 @@ Process:
   Arguments:
     SQL_command:
     - UPDATE `Component` SET `Component`.`Condition`='DESKTOPSC=1' WHERE `Component`.`Component`='EnpassDesktopShortcut'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/FileOpen/FileOpenPlugin-Win64.build.recipe.yaml
+++ b/FileOpen/FileOpenPlugin-Win64.build.recipe.yaml
@@ -29,42 +29,37 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the FileOpenPlugin install msi file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/FileZilla/FileZilla-Win64.build.recipe.yaml
+++ b/FileZilla/FileZilla-Win64.build.recipe.yaml
@@ -25,23 +25,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the FileZilla installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -50,33 +45,33 @@ Process:
   Comment: Rename the $R0 file to fzshellext_64.dll
   Arguments:
     overwrite: 'true'
-    source: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\$R0'
-    target: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\fzshellext_64.dll'
+    source: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\$R0'
+    target: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\fzshellext_64.dll'
 
 - Processor: Copier
   Comment: Copy the FileZilla installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\fzdefaults.xml'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\fzdefaults.xml'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\helpers\fzdefaults.xml'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\fzdefaults.xml'
 
 - Processor: PathDeleter
   Comment: Delete unnesessary folders from the FileZilla installer files
   Arguments:
     path_list:
-    - '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\$PLUGINSDIR'
-    - '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\$R2'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\$PLUGINSDIR'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\$R2'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -84,38 +79,38 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the FileZilla MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIAddFileHash
   Comment: Add files to the MSIHash table in the MSI-file
   Arguments:
     File2Hash:
-    - fzputtygen.exe|||%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\fzputtygen.exe
-    - fzsftp.exe|||%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\fzsftp.exe
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    - fzputtygen.exe|||%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\fzputtygen.exe
+    - fzsftp.exe|||%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\fzsftp.exe
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     remove_version_field: true
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps

--- a/GIMP/GIMP-Win64.BMS.recipe.yaml
+++ b/GIMP/GIMP-Win64.BMS.recipe.yaml
@@ -14,67 +14,9 @@ Input:
   DIP_SUBDIR: ML_x64
 
 Process:
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: |
-      <?xml version="1.0" encoding="ISO-8859-1"?>
-      <baramundiDeployScript Version="2420" LastChange="ddaatteettiimmee">
-      <META>
-      <INFO Vendor="" Name="" Version="" Author="Autopkg" Comment=""/>
-      <STATICVARS LoadInstallIni="1">
-      <BMSVars></BMSVars>
-      </STATICVARS>
-      </META>
-      <ACTIONS>
-      <ACTION type="Comment" level="0" breakpoint="0" ignore_error="0" comment="1" is_included="0" logging_enabled="1">
-      <DATA>
-      <VALUE>Uninstall-Script for GIMP-3 (Inno-Setup)</VALUE>
-      </DATA>
-      </ACTION>
-      <ACTION type="SetX64Mode" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <MODE>1</MODE>
-      </DATA>
-      </ACTION>
-      <ACTION type="SetVar" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <VARNAME>AppUninstallString</VARNAME>
-      <VALUE>0</VALUE>
-      <OPTIONS>0</OPTIONS>
-      </DATA>
-      </ACTION>
-      <ACTION type="EvalVar" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <VARNAME>AppUninstallString</VARNAME>
-      <SOURCE>Registry</SOURCE>
-      <OPTIONS>0</OPTIONS>
-      <Properties><PropertyEntry><Param>Key</Param><Value>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GIMP-3_is1</Value></PropertyEntry><PropertyEntry><Param>Registry</Param><Value>HKEY_LOCAL_MACHINE</Value></PropertyEntry><PropertyEntry><Param>Value</Param><Value>UninstallString</Value></PropertyEntry></Properties></DATA>
-      </ACTION>
-      <ACTION type="EvalVar" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <VARNAME>AppUninstallLocation</VARNAME>
-      <SOURCE>Registry</SOURCE>
-      <OPTIONS>0</OPTIONS>
-      <Properties><PropertyEntry><Param>Key</Param><Value>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\GIMP-3_is1</Value></PropertyEntry><PropertyEntry><Param>Registry</Param><Value>HKEY_LOCAL_MACHINE</Value></PropertyEntry><PropertyEntry><Param>Value</Param><Value>Inno Setup: App Path</Value></PropertyEntry></Properties></DATA>
-      </ACTION>
-      <ACTION type="LaunchProcess" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <COMMAND>{AppUninstallString}</COMMAND>
-      <PARAM>/VERYSILENT /NORESTART</PARAM>
-      <RETURNCODES>0</RETURNCODES>
-      <VARNAME></VARNAME>
-      <PIDVARNAME></PIDVARNAME>
-      <OPTIONS>3</OPTIONS>
-      </DATA>
-      <CONDITION op1="{AppUninstallString}" op="DOESNOTMATCH" op2="NOTFOUND" options="0"/>
-      </ACTION>
-      </ACTIONS>
-      </baramundiDeployScript>
-    rename_var: bds_content
-
 # - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   # Arguments:
-    # input_string: '%bds_content%'
+    # input_string: '|'
     # pattern_replace:
     # - pattern: SSuubbssttiittuuttee
       # repl: '%parsed_string%&#92;ML&#92;%NAME%%PF_STRING%_%build_ver%_ML'
@@ -82,7 +24,7 @@ Process:
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
     #input_string: '%parsed_string%'
-    input_string: '%bds_content%'
+    input_string: '|'
     pattern_replace:
     - pattern: ddaatteettiimmee
       repl: '%us_date% %time%'
@@ -91,7 +33,7 @@ Process:
   Comment: Generate the install.bds in the release dir.
   Arguments:
     file_content: '%parsed_string%'
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\u_%NAME%%PF_STRING%_%build_ver%.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\u_%NAME%%PF_STRING%_%build_ver%.bds'
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
     input_string: '%build_ver%'
@@ -170,9 +112,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/GIMP/GIMP-Win64.build.recipe.yaml
+++ b/GIMP/GIMP-Win64.build.recipe.yaml
@@ -24,17 +24,12 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the GIMP install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -42,19 +37,19 @@ Process:
   Comment: Extract the GIMP installer
   Arguments:
     inno_path: '%pathname%'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     # inno_compiler: '*'
     ignore_errors: False
 
 - Processor: FileFinder
   Comment: Get the GIMP exe file to extract the icons from
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\bin\gimp-console-*.exe'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\{app}\bin\gimp-console-*.exe'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the GIMP icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -69,12 +64,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/GitExtensions/GitExtensions-Win64.build.recipe.yaml
+++ b/GitExtensions/GitExtensions-Win64.build.recipe.yaml
@@ -23,28 +23,23 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 # - Processor: Copier
   # Comment: Save a copy of the corporate MST to the release dir.
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\PDF24_Enterprise_byAutoPkg.mst'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\PDF24_Enterprise_byAutoPkg.mst'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\helpers\PDF24_Enterprise_byAutoPkg.mst'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\PDF24_Enterprise_byAutoPkg.mst'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -59,13 +54,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Github/GithubDesktop-Win64.build.recipe.yaml
+++ b/Github/GithubDesktop-Win64.build.recipe.yaml
@@ -27,33 +27,28 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the GithubDesktop installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourcepkt\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\'
     extract_file: GithubDesktop-*-full.nupkg
 
 - Processor: FileFinder
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourcepkt\GithubDesktop-*-full.nupkg'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\GithubDesktop-*-full.nupkg'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
     exe_path: '%found_filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -61,33 +56,33 @@ Process:
 - Processor: Copier
   Comment: Copy the GithubDesktop installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\GithubDesktop\'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\GithubDesktop\'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\lib\net45\'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\lib\net45\'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate the GithubDesktop icons for BMS Kiosk.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%NAME%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -96,8 +91,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the GithubDesktop res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%NAME%.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -105,9 +100,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for GithubDesktop
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -115,14 +110,14 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the GithubDesktop MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\GithubDesktop.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\GithubDesktop.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%
     build_target: WIX

--- a/Github/GoogleEarthPro-Win64.download.recipe.yaml
+++ b/Github/GoogleEarthPro-Win64.download.recipe.yaml
@@ -22,8 +22,3 @@ Process:
   Arguments:
     expected_subject: 'CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US, SERIALNUMBER=3582691, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Delaware, OID.1.3.6.1.4.1.311.60.2.1.3=US'
     input_path: '%pathname%'
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version

--- a/Github/TortoiseGit-Win64.build.recipe.yaml
+++ b/Github/TortoiseGit-Win64.build.recipe.yaml
@@ -25,15 +25,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the TortoiseGit installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\'
     overwrite: 'true'
     # source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%*%PLATFORM%.msi'
     source_path: '%RECIPE_CACHE_DIR%\downloads\**'
@@ -42,72 +37,72 @@ Process:
   Arguments:
     cmdline_args:
     - /a
-    - '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_de_%PLATFORM%.msi'
-    - TARGETDIR=%BUILD_DIR%\%pkg_dir%\sourceunzipped\adm
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%_de_%PLATFORM%.msi'
+    - TARGETDIR=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\adm
     - /qn
     exe_file: 'msiexec.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourcepkt'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt'
     run_elevated: 'false'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Arguments:
     cmdline_args:
     - /a
-    - '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_fr_%PLATFORM%.msi'
-    - TARGETDIR=%BUILD_DIR%\%pkg_dir%\sourceunzipped\adm
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%_fr_%PLATFORM%.msi'
+    - TARGETDIR=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\adm
     - /qn
     exe_file: 'msiexec.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourcepkt'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt'
     run_elevated: 'false'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Arguments:
     cmdline_args:
     - /a
-    - '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_it_%PLATFORM%.msi'
-    - TARGETDIR=%BUILD_DIR%\%pkg_dir%\sourceunzipped\adm
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%_it_%PLATFORM%.msi'
+    - TARGETDIR=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\adm
     - /qn
     exe_file: 'msiexec.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourcepkt'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt'
     run_elevated: 'false'
 
 - Processor: Copier
   Comment: Copy the TortoiseGit MSI installer file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_%PLATFORM%.msi'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%_%PLATFORM%.msi'
 
 - Processor: Copier
   Comment: Copy the TortoiseGit language files to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\%NAME%\'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\adm\Program Files\TortoiseGit\**'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\adm\Program Files\TortoiseGit\**'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate the IrfanView icons for BMS Kiosk.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%EXE_NAME%'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\%NAME%\%EXE_NAME%'
     source_app: '%RECIPE_CACHE_DIR%\downloads\%NAME%_%PLATFORM%.msi'
     msi_icon_name: 'TGITIcon'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
@@ -117,7 +112,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -128,24 +123,24 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the TortoiseGit Languages MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     msm_dir: INSTALLDIR
     msm_feature: '%ADDON_NAME%'
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%_%version%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%_%version%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
     SQL_command:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('%ADDON_NAME%','DefaultFeature','%ADDON_NAME%','Install %ADDON_NAME%',11,1,'INSTALLDIR',8)
     - UPDATE `Property` SET `Property`.`Value`='%NAME% x64 ML' WHERE `Property`.`Property`='ProductName'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'

--- a/Google/GoogleChrome-Win.BMS.recipe.yaml
+++ b/Google/GoogleChrome-Win.BMS.recipe.yaml
@@ -21,7 +21,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -81,9 +81,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    #icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    #icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Google/GoogleChrome-Win.build.recipe.yaml
+++ b/Google/GoogleChrome-Win.build.recipe.yaml
@@ -38,20 +38,15 @@ Process:
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\GoogleChromeEnterprise-%PLATFORM%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\GoogleChromeEnterprise-%PLATFORM%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
     overwrite: 'true'
     source_path: '%pathname%'
@@ -60,15 +55,15 @@ Process:
   Comment: Applies the Settings-Transform to the GoogleChrome.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\GChrome_Enterprise_byAutoPkg.mst'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\GChrome_Enterprise_byAutoPkg.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Comment: get the ProductCode GUID from the MSI
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ChromiumSettings
   Comment: Generate the settings JSON and encode it
@@ -114,26 +109,26 @@ Process:
   Comment: Set the correct version / Harden the uninstall command / set the install options
   Arguments:
     SQL_command:
-    #- UPDATE `Property` SET `Property`.`Value`='%msiversion%' WHERE `Property`.`Property`='ProductVersion'
+    #- UPDATE `Property` SET `Property`.`Value`='%ver_major%.%ver_minor%.%build%' WHERE `Property`.`Property`='ProductVersion'
     #- UPDATE `Property` SET `Property`.`Value`='%chrm_settings_url%' WHERE `Property`.`Property`='MASTER_PREFERENCES'
     - UPDATE `InstallExecuteSequence` SET `InstallExecuteSequence`.`Condition`='((?ProductClientState=3) AND ($ProductClientState=2) AND NOT UPGRADINGPRODUCTCODE) AND UNINSTALLCMDLINE AND UNINSTALLCMDARGS' WHERE `InstallExecuteSequence`.`Action`='CallUninstaller'
     #- DELETE FROM `Upgrade` WHERE `Upgrade`.`ActionProperty`='UPGRADEFOUND'
     #- DELETE FROM `Upgrade` WHERE `Upgrade`.`ActionProperty`='NEWPRODUCTFOUND'
-    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','0.0.0','%msiversion%',768,'UPGRADEFOUND')
-    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','%msiversion%','',0,'NEWPRODUCTFOUND')
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','0.0.0','%ver_major%.%ver_minor%.%build%',768,'UPGRADEFOUND')
+    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','%ver_major%.%ver_minor%.%build%','',0,'NEWPRODUCTFOUND')
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -143,14 +138,14 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
 
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -160,6 +155,6 @@ Process:
       /j: Google Chrome x86 %build_ver% ML
       /o: Altered and hardened version for corporate use. %us_date% by AutoPkg
       /t: Google Chrome x86 %build_ver% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Google/GoogleChrome-Win64.BMS.recipe.yaml
+++ b/Google/GoogleChrome-Win64.BMS.recipe.yaml
@@ -21,7 +21,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -83,9 +83,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Google/GoogleChrome-Win64.build.recipe.yaml
+++ b/Google/GoogleChrome-Win64.build.recipe.yaml
@@ -37,20 +37,15 @@ Process:
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\GoogleChromeEnterprise-%PLATFORM%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\GoogleChromeEnterprise-%PLATFORM%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -58,14 +53,14 @@ Process:
   Comment: Applies the Settings-Transform to the GoogleChrome.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\GChrome64_Enterprise_byAutoPkg.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\GChrome64_Enterprise_byAutoPkg.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Comment: get the ProductCode GUID from the MSI
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ChromiumSettings
   Comment: Generate the settings JSON and encode it
@@ -111,26 +106,26 @@ Process:
   Comment: Set the correct version / Harden the uninstall command / set the install options
   Arguments:
     SQL_command:
-    #- UPDATE `Property` SET `Property`.`Value`='%msiversion%' WHERE `Property`.`Property`='ProductVersion'
+    #- UPDATE `Property` SET `Property`.`Value`='%ver_major%.%ver_minor%.%build%' WHERE `Property`.`Property`='ProductVersion'
     - UPDATE `Property` SET `Property`.`Value`='%chrm_settings_url%' WHERE `Property`.`Property`='MASTER_PREFERENCES'
     - UPDATE `InstallExecuteSequence` SET `InstallExecuteSequence`.`Condition`='((?ProductClientState=3) AND ($ProductClientState=2) AND NOT UPGRADINGPRODUCTCODE) AND UNINSTALLCMDLINE AND UNINSTALLCMDARGS' WHERE `InstallExecuteSequence`.`Action`='CallUninstaller'
     #- DELETE FROM `Upgrade` WHERE `Upgrade`.`ActionProperty`='UPGRADEFOUND'
     #- DELETE FROM `Upgrade` WHERE `Upgrade`.`ActionProperty`='NEWPRODUCTFOUND'
-    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','0.0.0','%msiversion%',768,'UPGRADEFOUND')
-    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','%msiversion%','',0,'NEWPRODUCTFOUND')
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','0.0.0','%ver_major%.%ver_minor%.%build%',768,'UPGRADEFOUND')
+    #- INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{C1DFDF69-5945-32F2-A35E-EE94C99C7CF4}','%ver_major%.%ver_minor%.%build%','',0,'NEWPRODUCTFOUND')
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -140,13 +135,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -156,6 +151,6 @@ Process:
       /j: Google Chrome x64 %build_ver% ML
       /o: Altered and hardened version for corporate use. %us_date% by AutoPkg
       /t: Google Chrome x64 %build_ver% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Google/GoogleChromeMSI-Win.download.recipe.yaml
+++ b/Google/GoogleChromeMSI-Win.download.recipe.yaml
@@ -17,11 +17,6 @@ Process:
     file_content: '%match%'
     file_path: '%RECIPE_CACHE_DIR%\version.txt'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%ver_major%.%ver_minor%.%build%'
-    rename_var: msiversion
-
 - Processor: URLDownloader
   Arguments:
     filename: GoogleChromeEnterprise-%PLATFORM%.msi

--- a/Google/GoogleEarthPro-Win64.build.recipe.yaml
+++ b/Google/GoogleEarthPro-Win64.build.recipe.yaml
@@ -34,26 +34,21 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:release:read
-    org_ver: '%version%'
+    org_ver: '%msi_value%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\GoogleEarthPro-%PLATFORM%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\GoogleEarthPro-%PLATFORM%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%msi_value%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%-%PLATFORM%.msi'
 
@@ -61,20 +56,20 @@ Process:
   # Comment: Applies the Settings-Transform to the GoogleChrome.msi in the release folder
   # Arguments:
     # mode: -a
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
-    # mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\GChrome64_Enterprise_byAutoPkg.mst'
+    # msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%msi_value%%LANG_STRING%.msi'
+    # mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\GChrome64_Enterprise_byAutoPkg.mst'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%msi_value%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -84,14 +79,14 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%msi_value%%LANG_STRING%.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%msi_value%%LANG_STRING%.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: EndOfCheckPhase

--- a/Google/GoogleEarthPro-Win64.download.recipe.yaml
+++ b/Google/GoogleEarthPro-Win64.download.recipe.yaml
@@ -22,8 +22,3 @@ Process:
   Arguments:
     expected_subject: 'CN=Google LLC, O=Google LLC, L=Mountain View, S=California, C=US'
     input_path: '%pathname%'
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version

--- a/Google/GoogleSync-Win64.build.recipe.yaml
+++ b/Google/GoogleSync-Win64.build.recipe.yaml
@@ -19,21 +19,16 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read
-    org_ver: '%version%'
+    org_ver: '%msi_value%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::_ML'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -48,17 +43,17 @@ Process:
     - UPDATE `Component` SET `Component`.`Condition`='GOOGLESHEETSDESKTOPSHORTCUT' WHERE `Component`.`Component`='GoogleSheetsDesktopShortcutComponent'
     - UPDATE `Component` SET `Component`.`Condition`='GOOGLESLIDESDESKTOPSHORTCUT' WHERE `Component`.`Component`='GoogleSlidesDesktopShortcutComponent'
     - UPDATE `Component` SET `Component`.`Condition`='GOOGLEDOCSDESKTOPSHORTCUT' WHERE `Component`.`Component`='GoogleDocsDesktopShortcutComponent'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Google/GoogleSyncMSI-Win64.download.recipe.yaml
+++ b/Google/GoogleSyncMSI-Win64.download.recipe.yaml
@@ -24,8 +24,3 @@ Process:
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version

--- a/Greenshot/Greenshot-Win64.BMS.recipe.yaml
+++ b/Greenshot/Greenshot-Win64.BMS.recipe.yaml
@@ -73,9 +73,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_PRD%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_PRD%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_PRD%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_PRD%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Greenshot/Greenshot-Win64.build.recipe.yaml
+++ b/Greenshot/Greenshot-Win64.build.recipe.yaml
@@ -27,16 +27,11 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/InnoEditor
   Comment: Extract the Greenshot installer
   Arguments:
     inno_path: '%pathname%'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     ignore_errors: False
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
@@ -48,9 +43,9 @@ Process:
     - /v
     - /i
     - "https://getgreenshot.org/thank-you"
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\install_script.iss'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\install_script.iss'
     - '>'
-    - '%BUILD_DIR%\%pkg_dir%\helpers\install_script.iss'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\install_script.iss'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
@@ -60,7 +55,7 @@ Process:
     cmdline_args:
     - '-i'
     - 's/PrivilegesRequired=lowest/VersionInfoVersion=%version%/'
-    - '%BUILD_DIR%\%pkg_dir%\helpers\install_script.iss'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\install_script.iss'
     exe_file: 'C:\Program Files\Git\usr\bin\sed.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
 
@@ -71,7 +66,7 @@ Process:
     - '-i'
     - '-e'
     - '"s/^Subkey:/Root: HKA; &/"'
-    - '%BUILD_DIR%\%pkg_dir%\helpers\install_script.iss'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\install_script.iss'
     exe_file: 'C:\Program Files\Git\usr\bin\sed.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
  
@@ -81,7 +76,7 @@ Process:
     # cmdline_args:
     # - '-i'
     # - 's/AppUpdatesURL=https:\/\/getgreenshot.org/VersionInfoVersion=%version%/'
-    # - '%BUILD_DIR%\%pkg_dir%\helpers\install_script.iss'
+    # - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\install_script.iss'
     # exe_file: 'C:\Program Files\Git\usr\bin\sed.exe'
     # exe_folder: '%RECIPE_CACHE_DIR%'
 
@@ -92,12 +87,12 @@ Process:
     - /C
     - copy
     - /y
-    - '%BUILD_DIR%\%pkg_dir%\helpers\install_script.iss'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\install_script.iss'
     - /a
     - '+'
-    - '%BUILD_DIR%\%pkg_dir%\helpers\Code.iss'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Code.iss'
     - /a
-    - '%BUILD_DIR%\%pkg_dir%\sourceunzipped\install_script.iss'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\install_script.iss'
     - /a
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
@@ -106,19 +101,19 @@ Process:
   Comment: Create the new Greenshot installer
   Arguments:
     inno_compiler: 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     ignore_errors: False
 
 - Processor: Copier
   Arguments:
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Output\Greenshot_x64.exe'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Output\Greenshot_x64.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from Greenshot
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -133,13 +128,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/IBM/SpectrumProtect-Win64.build.recipe.yaml
+++ b/IBM/SpectrumProtect-Win64.build.recipe.yaml
@@ -23,15 +23,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the SpectrumProtect installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
@@ -39,25 +34,25 @@ Process:
   Comment: Extract the SpectrumProtect zip archive
   Arguments:
     exe_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: FileFinder
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\**\Disk1'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\**\Disk1'
 
 - Processor: Copier
   Comment: Copy the SpectrumProtect installer file to the Release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\TSMClient'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\TSMClient'
     overwrite: 'true'
     source_path: '%found_filename%/**'
 
 - Processor: FileFinder
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\TSM*'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\TSM*'
 
 - Processor: PathDeleter
   Comment: Delete the contents of sourceunzipped
@@ -66,12 +61,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Influxdata/Telegraf-Win64.build.recipe.yaml
+++ b/Influxdata/Telegraf-Win64.build.recipe.yaml
@@ -27,24 +27,19 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Telegraf installer files to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'False'
@@ -52,26 +47,26 @@ Process:
 - Processor: Copier
   Comment: Copy the Telegraf conf file to the wix project dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\telegraf.conf'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\telegraf.conf'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\telegraf.conf'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\telegraf.conf'
  
 - Processor: WindowsSignatureVerifier
   Arguments:
     expected_subject: CN="InfluxData, Inc", O="InfluxData, Inc", L=San Francisco, S=California, C=US
-    input_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
+    input_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%NAME%.exe'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from Telegraf
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%NAME%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -80,8 +75,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the Telegraf res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%NAME%.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -89,9 +84,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Telegraf
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -100,20 +95,20 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\version.wxi'
     # template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -134,9 +129,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Telegraf MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -144,4 +139,4 @@ Process:
   Arguments:
     SQL_command:
     - DELETE FROM `MsiFileHash` WHERE `MsiFileHash`.`File_`='extern.telegraf.conf'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'

--- a/Inkscape/Inkscape-Win64.BMS.recipe.yaml
+++ b/Inkscape/Inkscape-Win64.BMS.recipe.yaml
@@ -15,7 +15,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -77,9 +77,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Inkscape/Inkscape-Win64.build.recipe.yaml
+++ b/Inkscape/Inkscape-Win64.build.recipe.yaml
@@ -25,15 +25,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -48,18 +43,18 @@ Process:
     - INSERT INTO `Directory` (`Directory`.`Directory`,`Directory`.`Directory_Parent`,`Directory`.`DefaultDir`) VALUES ('SHORTCUTDIR','ProgramMenuFolder','Graphics')
     - UPDATE `Shortcut` SET `Shortcut`.`Directory_`='SHORTCUTDIR' WHERE `Shortcut`.`Component_`='CM_SHORTCUT_inkscape'
     - INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`,`Upgrade`.`ActionProperty`) VALUES ('{DE920DF4-C143-45D5-93E1-B1A88C678E8C}','0.40.0','0.48.5','260','UPGRADE_2')
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     msi_icon_name: 'ProductIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -67,13 +62,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/IrfanView/IrfanView-Win64.BMS.recipe.yaml
+++ b/IrfanView/IrfanView-Win64.BMS.recipe.yaml
@@ -18,7 +18,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -95,9 +95,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/IrfanView/IrfanView-Win64.build.recipe.yaml
+++ b/IrfanView/IrfanView-Win64.build.recipe.yaml
@@ -29,23 +29,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the IrfanView installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%exe_file%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%exe_file%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%exe_file%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the IrfanView installer to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%exe_file%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%exe_file%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -53,15 +48,15 @@ Process:
 - Processor: Copier
   Comment: Copy the IrfanView plugins installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the IrfanView plugins installer to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Plugins'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\Plugins'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -74,15 +69,15 @@ Process:
 - Processor: Copier
   Comment: Copy the IrfanView plugins installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_French_Lng.zip'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%_French_Lng.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%_French_Lng.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the IrfanView plugins installer to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_French_Lng.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Languages'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%_French_Lng.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\Languages'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -95,28 +90,28 @@ Process:
 - Processor: Copier
   Comment: Copy the IrfanView plugins installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_Italian_Lng.zip'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%_Italian_Lng.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%_Italian_Lng.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the IrfanView plugins installer to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%_Italian_Lng.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Languages'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%_Italian_Lng.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\Languages'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 # - Processor: FileFinder
   # Arguments:
-    # pattern: '%BUILD_DIR%\%pkg_dir%\sourcepkt\GithubDesktop-*-full.nupkg'
+    # pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\GithubDesktop-*-full.nupkg'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   # Comment: Extract the autopkg zip archive
   # Arguments:
     # exe_path: '%found_filename%'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
     # extract_file: '*'
     # ignore_pattern: ''
     # preserve_paths: 'True'
@@ -124,33 +119,33 @@ Process:
 # - Processor: Copier
   # Comment: Copy the IrfanView installer file to the build dir
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\GithubDesktop\'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\GithubDesktop\'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\lib\net45\'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\lib\net45\'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate the IrfanView icons for BMS Kiosk.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%EXE_NAME%'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%EXE_NAME%'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -159,8 +154,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the IrfanView res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%EXE_NAME%'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%EXE_NAME%'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -168,9 +163,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for IrfanView
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -185,12 +180,12 @@ Process:
     - '>>'
     - user_view64.ini
     exe_file: 'cmd.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\version.wxi'
     # template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -213,7 +208,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the IrfanView MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX

--- a/Jabref/Jabref-Win64.build.recipe.yaml
+++ b/Jabref/Jabref-Win64.build.recipe.yaml
@@ -17,39 +17,29 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Comment: Create the build environment
   Arguments:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: release:read
-    org_ver: '%version%'
+    org_ver: '%msi_value%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Get the icon library from the MSI and generate the Kiosk-icons.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -67,17 +57,17 @@ Process:
   Arguments:
     SQL_command:
     - UPDATE `Component` SET `Component`.`Condition`='DESKTOPSC=1' WHERE `Component`.`Component`='cshortcuted19f475eb9a3edfaffe9fd0a73bd4ff'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Jupyterlab/JupyterLab-Desktop-Win64.build.recipe.yaml
+++ b/Jupyterlab/JupyterLab-Desktop-Win64.build.recipe.yaml
@@ -27,16 +27,11 @@ Process:
     ver_fields: '4'
     create_AS_ver: 'true'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   #Comment: Copy the Element installer file to the build dir
   Comment: Copy the JupyterLab-Desktop installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     #source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
     source_path: '%pathname%'
@@ -44,15 +39,15 @@ Process:
 # - Processor: Copier
   # Comment: Copy the JupyterLab-Desktop installer file to the release dir
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     # overwrite: 'true'
     # source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the JupyterLab-Desktop NSIS installer to the sourceunzipped dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -60,22 +55,22 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the JupyterLab-Desktop NSIS installer to the sourceunzipped dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\$PLUGINSDIR\app-64.7z'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAMESHORT%\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\$PLUGINSDIR\app-64.7z'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAMESHORT%\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAMESHORT%\%NAMESHORT%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAMESHORT%\%NAMESHORT%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -84,8 +79,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the Eclipse res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAMESHORT%\%NAMESHORT%.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAMESHORT%\%NAMESHORT%.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -93,9 +88,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Eclipse-Java
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -104,20 +99,20 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\version.wxi'
     # template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -138,8 +133,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Eclipse MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAMESHORT%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAMESHORT%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAMESHORT%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAMESHORT%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAMESHORT%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\wixproject\%NAMESHORT%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     #;"ASVersion=%AS_ver%"
     build_target: WIX

--- a/KDE/KDiff3-Win64.build.recipe.yaml
+++ b/KDE/KDiff3-Win64.build.recipe.yaml
@@ -25,17 +25,12 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -53,8 +48,8 @@ Process:
   Comment: Extract the install executable
   Arguments:
     exe_path: '%found_filename%'
-    #exe_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    #exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     extract_file: 'bin\kdiff3.exe'
     ignore_pattern: ''
     preserve_paths: 'False'
@@ -62,14 +57,14 @@ Process:
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the icon and create custom icons for the deployment.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: bl
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\kdiff3.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\kdiff3.exe'
     # msi_icon_name: 'ProductIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -77,12 +72,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/KeePassXC/KeePassXC-Win64.BMS.recipe.yaml
+++ b/KeePassXC/KeePassXC-Win64.BMS.recipe.yaml
@@ -13,7 +13,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -72,9 +72,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons\*.*'
 
 - Processor: EndOfCheckPhase

--- a/KeePassXC/KeePassXC-Win64.build.recipe.yaml
+++ b/KeePassXC/KeePassXC-Win64.build.recipe.yaml
@@ -23,34 +23,29 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the MSI-file to the sourceunzipped dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%%PF_STRING%_%version%_raw.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\%NAME%%PF_STRING%_%version%_raw.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Copy the MSI-file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -60,9 +55,9 @@ Process:
   Comment: Applies the transforms to the MSI-file in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     mst_paths:
-    - '%BUILD_DIR%\%pkg_dir%\helpers\KPXC-UserSettings-02.mst'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\helpers\KPXC-UserSettings-02.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
@@ -70,18 +65,18 @@ Process:
       /j: KeePassXC %version%
       /o: Slightely altered (AutoUpdate disabled). %us_date% by AutoPkg
       /t: KeePassXC %version%
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/Keepass/Keepass-Win.BMS.recipe.yaml
+++ b/Keepass/Keepass-Win.BMS.recipe.yaml
@@ -18,7 +18,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -80,9 +80,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Keepass/Keepass-Win.build.recipe.yaml
+++ b/Keepass/Keepass-Win.build.recipe.yaml
@@ -23,104 +23,99 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Keepass_%build_ver%%LANG_STRING%
-    rename_var: pkg_dir
-
 # - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   # Arguments:
-    # build_dir: '%BUILD_DIR%\%pkg_dir%'
+    # build_dir: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%'
     # build_ver: '%build_ver%'
     # org_ver: '%version%'
     # prop_file: wixproject\global.prop
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-Keepass_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\read\create-log-Keepass_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-Keepass_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\read\readme-Keepass_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%_%build_ver%.msi'
+    destination_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourceunzipped\%NAME%_%build_ver%.msi'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%.msi'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\release\%NAME%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%.msi'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\KeePass.config.enforced.xml'
+    destination_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%NAME%\KeePass.config.enforced.xml'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\helpers\KeePass.config.enforced.xml'
+    source_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\helpers\KeePass.config.enforced.xml'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-ger.zip'
+    destination_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-ger.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%-ger.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Keepass german language file to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-ger.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Languages'
+    exe_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-ger.zip'
+    extract_dir: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%NAME%\Languages'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-fra.zip'
+    destination_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-fra.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%-fra.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Keepass french language file to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-fra.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Languages'
+    exe_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-fra.zip'
+    extract_dir: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%NAME%\Languages'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-ita.zip'
+    destination_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-ita.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%-ita.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Keepass italian language file to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-ita.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Languages'
+    exe_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-ita.zip'
+    extract_dir: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%NAME%\Languages'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-spa.zip'
+    destination_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-spa.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%-spa.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Keepass spanish language file to the wixproject dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-spa.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Languages'
+    exe_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\sourcepkt\%NAME%-spa.zip'
+    extract_dir: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%NAME%\Languages'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -128,16 +123,16 @@ Process:
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate the IrfanView icons for BMS Kiosk.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%EXE_NAME%'
+    #source_app: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%NAME%\%EXE_NAME%'
     #source_app: '%RECIPE_CACHE_DIR%\downloads\%NAME%_%PLATFORM%.msi'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\Keepass_256.png'
+    source_app: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\helpers\Keepass_256.png'
     msi_icon_name: 'Icon0'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -146,7 +141,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   Comment: Define variables for the WIX build process to the version.wxi file
   Arguments:
-    preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\version.wxi'
+    preproc_file: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\version.wxi'
     template_file: None
     new_settings:
     - define: 'version="%build_ver%"'
@@ -157,20 +152,20 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the TortoiseGit Languages MSM module addon.
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%.build'
+    build_folder: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%ADDON_NAME%;BuildDir=%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIimportMergeModule
   Arguments:
-    log_file_abs: '%BUILD_DIR%\%pkg_dir%\wixproject\MSM-log.txt'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    log_file_abs: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\MSM-log.txt'
+    msi_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     msm_dir: TARGETDIR
     msm_feature: '%ADDON_NAME%'
-    msm_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%ADDON_NAME%%PF_STRING%_%build_ver%.msm'
-    pkg_dir_abs: '%BUILD_DIR%\%pkg_dir%'
-    temp_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    msm_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject\%ADDON_NAME%%PF_STRING%_%build_ver%.msm'
+    pkg_dir_abs: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%'
+    temp_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\wixproject'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
@@ -178,7 +173,7 @@ Process:
     - INSERT INTO `Feature` (`Feature`.`Feature`,`Feature`.`Feature_Parent`,`Feature`.`Title`,`Feature`.`Description`, `Feature`.`Display`,`Feature`.`Level`,`Feature`.`Directory_`,`Feature`.`Attributes`) VALUES ('%ADDON_NAME%','','%ADDON_NAME%','Install Language and Config',11,1,'TARGETDIR',8)
     - UPDATE `Property` SET `Property`.`Value`='%NAME% ML' WHERE `Property`.`Property`='ProductName'
     - DELETE FROM `Shortcut` WHERE `Shortcut`.`Directory_` = 'DesktopFolder'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
@@ -189,6 +184,6 @@ Process:
       /j: Keepass ML
       /o: Extended with Langpacks and Cfg for corporate use. %us_date% by AutoPkg
       /t: Keepass ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\Keepass_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Keepass_%build_ver%%LANG_STRING%\release\Keepass_%build_ver%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/Lenovo/ThinkpadSystemUpdate-Win.BMS.recipe.yaml
+++ b/Lenovo/ThinkpadSystemUpdate-Win.BMS.recipe.yaml
@@ -15,22 +15,12 @@ Input:
   DIP_SUBDIR: ML
 
 Process:
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: /SP- /VERYSILENT /NORESTART /LOG="{TTEEMMPP}\i_sysupd_%build_ver%.log"
-    rename_var: inst_param
-
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
-    input_string: '%inst_param%'
+    input_string: '%parsed_string%'
     pattern_replace:
     - pattern: TTEEMMPP
       repl: '%TEMP%'
-
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%parsed_string%'
-    rename_var: inst_param
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -47,7 +37,7 @@ Process:
     bms_app_comment: 'Imported by: AutoPkg, %us_date% %time%'
     bms_app_conschecks: "CheckAppRC=0,3010\r\nDeinstall.CheckAppRC=0,1605,3010"
     bms_app_installcmd: '{DIP}\Apl\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%\%NAMESHORT%_%build_ver%%LANG_STRING%.exe'
-    bms_app_installparm: '%inst_param%'
+    bms_app_installparm: '%parsed_string%'
     bms_app_integration:
     - appname: '%NAME%'
       bundles:
@@ -82,8 +72,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'    
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'    
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
 
 - Processor: EndOfCheckPhase

--- a/Lenovo/ThinkpadSystemUpdate-Win.build.recipe.yaml
+++ b/Lenovo/ThinkpadSystemUpdate-Win.build.recipe.yaml
@@ -35,28 +35,23 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the Lenovo System Update install exe file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\system_update_%build_ver%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\system_update_%build_ver%%LANG_STRING%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-ThinkpadSystemUpdate_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-ThinkpadSystemUpdate_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-ThinkpadSystemUpdate_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-ThinkpadSystemUpdate_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/LibreOffice/LibreOffice-Win64.build.recipe.yaml
+++ b/LibreOffice/LibreOffice-Win64.build.recipe.yaml
@@ -26,28 +26,23 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     msi_icon_name: 'soffice.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -55,13 +50,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Logitech/LogiOptionsPlus-Win64.BMS.recipe.yaml
+++ b/Logitech/LogiOptionsPlus-Win64.BMS.recipe.yaml
@@ -78,9 +78,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAMESHORT%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Logitech/LogiOptionsPlus-Win64.build.recipe.yaml
+++ b/Logitech/LogiOptionsPlus-Win64.build.recipe.yaml
@@ -29,21 +29,16 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
     overwrite: 'true'
     source_path: '%pathname%'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from Telegraf
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -58,13 +53,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Lyx/LyX-Win64.build.recipe.yaml
+++ b/Lyx/LyX-Win64.build.recipe.yaml
@@ -40,11 +40,6 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.jazzace.processors/TextSearcher
   Arguments:
     # download_changed: False
@@ -59,13 +54,13 @@ Process:
 - Processor: Copier
   Comment: Copy the LyX install exe file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -83,12 +78,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Macrobond/Macrobond-Win64.build.recipe.yaml
+++ b/Macrobond/Macrobond-Win64.build.recipe.yaml
@@ -26,15 +26,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Macrobond installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
@@ -42,19 +37,19 @@ Process:
   Comment: Extract the Macrobond zip archive
   Arguments:
     exe_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\release'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'False'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Mendeley/ReferenceManager-Win64.build.recipe.yaml
+++ b/Mendeley/ReferenceManager-Win64.build.recipe.yaml
@@ -27,23 +27,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the Reference Manager install exe file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -58,12 +53,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Mersive/SolsticeClient-Win64.build.recipe.yaml
+++ b/Mersive/SolsticeClient-Win64.build.recipe.yaml
@@ -20,32 +20,22 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Comment: Create the build environment
   Arguments:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: helpers:release:read
-    org_ver: '%version%'
+    org_ver: '%msi_value%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::_ML'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -53,18 +43,18 @@ Process:
   Comment: Apply the settings an FW transform to the SolsticeClient MSI
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\SolClnt_DTSC_FW2_Conf.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\SolClnt_DTSC_FW2_Conf.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -73,14 +63,14 @@ Process:
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate the Adobe Reader icons for BMS Kiosk.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\solstice-512.png'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\solstice-512.png'
     #msi_icon_name: 'ARPPRODUCTICON.exe'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'

--- a/Microsoft/DotNetCoreDesktopRuntime-Win64.build.recipe.yaml
+++ b/Microsoft/DotNetCoreDesktopRuntime-Win64.build.recipe.yaml
@@ -32,26 +32,21 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 

--- a/Microsoft/DotNetDesktopRuntime-Win.build.recipe.yaml
+++ b/Microsoft/DotNetDesktopRuntime-Win.build.recipe.yaml
@@ -32,26 +32,21 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 

--- a/Microsoft/DotNetDesktopRuntime-Win64.BMS.recipe.yaml
+++ b/Microsoft/DotNetDesktopRuntime-Win64.BMS.recipe.yaml
@@ -58,8 +58,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
+    read_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\*-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/DotNetDesktopRuntime-Win64.build.recipe.yaml
+++ b/Microsoft/DotNetDesktopRuntime-Win64.build.recipe.yaml
@@ -32,26 +32,21 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 

--- a/Microsoft/MicrosoftEdge-Win.BMS.recipe.yaml
+++ b/Microsoft/MicrosoftEdge-Win.BMS.recipe.yaml
@@ -15,11 +15,11 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%msi_value%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
-    input_string: '%version%'
+    input_string: '%msi_value%'
     pattern_replace:
     - pattern: \.
       repl: _
@@ -31,7 +31,7 @@ Process:
     bms_app_category: baramundi Application
     bms_app_comment: 'Imported by: AutoPkg, %us_date% %time%'
     bms_app_conschecks: "CheckAppRC=0,3010\r\nDeinstall.CheckAppRC=0,1605,3010"
-    bms_app_installcmd: '{DIP}\Apl\EdgeChromium\%parsed_string%\ML\%NAME%%PF_STRING%_%version%_ML.msi'
+    bms_app_installcmd: '{DIP}\Apl\EdgeChromium\%parsed_string%\ML\%NAME%%PF_STRING%_%msi_value%_ML.msi'
     bms_app_installparm: /qn /norestart ALLUSERS=1
     bms_app_integration:
     - appname: EdgeChromium
@@ -65,11 +65,11 @@ Process:
     bms_app_uopt_rebootbhv: NoReboot
     bms_app_valid4os: '%BMS_VALID4OS%'
     bms_app_vendor: '%VENDOR%'
-    bms_app_version: '%version% ML (x86)'
+    bms_app_version: '%msi_value% ML (x86)'
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\ML'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%msi_value%_ML.msi|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\ML'
+    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%msi_value%_ML.txt|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/MicrosoftEdge-Win.build.recipe.yaml
+++ b/Microsoft/MicrosoftEdge-Win.build.recipe.yaml
@@ -21,31 +21,26 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Arguments:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read:helpers
-    org_ver: '%version%'
-    pkg_dir: MicrosoftEdge%PF_STRING%_%version%_ML
+    org_ver: '%msi_value%'
+    pkg_dir: MicrosoftEdge%PF_STRING%_%msi_value%_ML
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-MicrosoftEdge%PF_STRING%_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-MicrosoftEdge%PF_STRING%_%msi_value%_ML.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-MicrosoftEdge%PF_STRING%_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-MicrosoftEdge%PF_STRING%_%msi_value%_ML.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
@@ -56,14 +51,14 @@ Process:
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%msi_value%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%msi_value%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ChromiumSettings
   Arguments:
@@ -108,7 +103,7 @@ Process:
   Comment: Applies the Settings-Transform to the MicrosoftEdge.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%msi_value%_ML.msi'
     mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\MsEdge64_ETHZchanges.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -116,16 +111,16 @@ Process:
     SQL_command:
     - UPDATE `Property` SET `Property`.`Value`='%chrm_settings_url%' WHERE `Property`.`Property`='MASTER_PREFERENCES'
     - UPDATE `InstallExecuteSequence` SET `InstallExecuteSequence`.`Condition`='((?ProductClientState=3) AND ($ProductClientState=2) AND NOT UPGRADINGPRODUCTCODE) AND UNINSTALLCMDLINE AND UNINSTALLCMDARGS' WHERE `InstallExecuteSequence`.`Action`='CallUninstaller'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%msi_value%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Edge Chromium x64 %version% ML
+      /j: Edge Chromium x64 %msi_value% ML
       /o: 'Altered version for enterprise. %us_date% by AutoPkg'
-      /t: Edge Chromium x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%version%_ML.msi'
+      /t: Edge Chromium x64 %msi_value% ML
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge%PF_STRING%_%msi_value%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/MicrosoftEdge-Win64.BMS.recipe.yaml
+++ b/Microsoft/MicrosoftEdge-Win64.BMS.recipe.yaml
@@ -14,11 +14,11 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%msi_value%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
-    input_string: '%version%'
+    input_string: '%msi_value%'
     pattern_replace:
     - pattern: \.
       repl: _
@@ -30,7 +30,7 @@ Process:
     bms_app_category: baramundi Application
     bms_app_comment: 'Imported by: AutoPkg, %us_date% %time%'
     bms_app_conschecks: "CheckAppRC=0,3010\r\nDeinstall.CheckAppRC=0,1605,3010"
-    bms_app_installcmd: '{DIP}\Apl\EdgeChromium\%parsed_string%\ML_x64\%NAME%%PF_STRING%_%version%_ML.msi'
+    bms_app_installcmd: '{DIP}\Apl\EdgeChromium\%parsed_string%\ML_x64\%NAME%%PF_STRING%_%msi_value%_ML.msi'
     bms_app_installparm: /qn /norestart ALLUSERS=1
     bms_app_integration:
     - appname: EdgeChromium
@@ -64,11 +64,11 @@ Process:
     bms_app_uopt_rebootbhv: NoReboot
     bms_app_valid4os: Windows7_x64,Windows8_x64,Windows10_x64,WindowsServer2012_x64,WindowsServer2016_x64,WindowsServer2019_x64
     bms_app_vendor: '%VENDOR%'
-    bms_app_version: '%version% ML (x64)'
+    bms_app_version: '%msi_value% ML (x64)'
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\ML_x64'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%msi_value%_ML.msi|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\ML_x64'
+    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%msi_value%_ML.txt|%BMS_IMPORT_PATH_TST%\EdgeChromium\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/MicrosoftEdge-Win64.build.recipe.yaml
+++ b/Microsoft/MicrosoftEdge-Win64.build.recipe.yaml
@@ -20,31 +20,26 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Arguments:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read:helpers
-    org_ver: '%version%'
-    pkg_dir: MicrosoftEdge_64_%version%_ML
+    org_ver: '%msi_value%'
+    pkg_dir: MicrosoftEdge_64_%msi_value%_ML
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-MicrosoftEdge_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-MicrosoftEdge_64_%msi_value%_ML.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-MicrosoftEdge_64_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-MicrosoftEdge_64_%msi_value%_ML.txt'
+    new_ver: '%msi_value%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
@@ -55,14 +50,14 @@ Process:
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%msi_value%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%msi_value%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ChromiumSettings
   Arguments:
@@ -107,7 +102,7 @@ Process:
   Comment: Applies the Settings-Transform to the MicrosoftEdge.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%msi_value%_ML.msi'
     mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\MsEdge64_ETHZchanges.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -115,16 +110,16 @@ Process:
     SQL_command:
     - UPDATE `Property` SET `Property`.`Value`='%chrm_settings_url%' WHERE `Property`.`Property`='MASTER_PREFERENCES'
     - UPDATE `InstallExecuteSequence` SET `InstallExecuteSequence`.`Condition`='((?ProductClientState=3) AND ($ProductClientState=2) AND NOT UPGRADINGPRODUCTCODE) AND UNINSTALLCMDLINE AND UNINSTALLCMDARGS' WHERE `InstallExecuteSequence`.`Action`='CallUninstaller'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%msi_value%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
     cmnds_sinfo:
-      /j: Edge Chromium x64 %version% ML
+      /j: Edge Chromium x64 %msi_value% ML
       /o: 'Altered version for enterprise. %us_date% by AutoPkg'
-      /t: Edge Chromium x64 %version% ML
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%version%_ML.msi'
+      /t: Edge Chromium x64 %msi_value% ML
+    msi_path: '%BUILD_DIR%\%pkg_dir%\release\MicrosoftEdge_64_%msi_value%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/MicrosoftEdgeWebDriver-Win64.build.recipe.yaml
+++ b/Microsoft/MicrosoftEdgeWebDriver-Win64.build.recipe.yaml
@@ -26,23 +26,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Edge Webdriver zip file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Edge Webdriver exe to the release dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\release\'
+    exe_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\'
     extract_file: 'msedgedriver.exe'
     ignore_pattern: ''
     preserve_paths: 'False'
@@ -50,23 +45,23 @@ Process:
 - Processor: WindowsSignatureVerifier
   Arguments:
     expected_subject: CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
-    input_path: '%BUILD_DIR%\%pkg_dir%\release\msedgedriver.exe'
+    input_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\msedgedriver.exe'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    # destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
     # overwrite: 'true'
     # source_path: '%pathname%'
 

--- a/Microsoft/MicrosoftEdgeWebDriver-Win64.install.recipe.yaml
+++ b/Microsoft/MicrosoftEdgeWebDriver-Win64.install.recipe.yaml
@@ -15,7 +15,7 @@ Process:
   Arguments:
     destination_path: 'C:\Tools\MSITools\msedgedriver.exe'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\release\msedgedriver.exe'
+    source_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\msedgedriver.exe'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   # Comment: stop the MS Edge browser

--- a/Microsoft/MicrosoftPowerToys-Win64.BMS.recipe.yaml
+++ b/Microsoft/MicrosoftPowerToys-Win64.BMS.recipe.yaml
@@ -14,7 +14,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.msi'
+    msi_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -64,8 +64,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%VENDOR%_%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
+    read_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\*-%VENDOR%_%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/MicrosoftPowerToys-Win64.build.recipe.yaml
+++ b/Microsoft/MicrosoftPowerToys-Win64.build.recipe.yaml
@@ -27,45 +27,40 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Git install exe file to the sourcepkt dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\sourcepkt\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDarkExtractor
   Comment: Extract the MSI-file from install exe file to the sourceunzipped dir, using Wix dark
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\sourcepkt\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    extract_dir: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\sourceunzipped'
 
 - Processor: FileFinder
   Comment: Find the exact path to extracted MSI-file
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\**\*.msi'
+    pattern: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\sourceunzipped\**\*.msi'
 
 - Processor: Copier
   Comment: Copy the extracted MSI-file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.msi'
     overwrite: 'true'
     source_path: '%found_filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Microsoft/MicrosoftWebView2EvergreenBootstrapper-Win64.BMS.recipe.yaml
+++ b/Microsoft/MicrosoftWebView2EvergreenBootstrapper-Win64.BMS.recipe.yaml
@@ -44,8 +44,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\ML_x64'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\ML_x64'
+    read_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\*-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\DEV'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\bms_app_integration.json'
     bms_app_integration:
     - appname: '%NAME%'
@@ -86,7 +86,7 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER2%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_PRD%\MSEdgeWebView2\%parsed_string%\ML_x64'
+    inst_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_PRD%\MSEdgeWebView2\%parsed_string%\ML_x64'
     json_file_dest: '%BMS_IMPORT_PATH_PRD%\MSEdgeWebView2\bms_app_integration.json'
     bms_app_integration:
     - appname: '%NAME%'

--- a/Microsoft/MicrosoftWebView2EvergreenBootstrapper-Win64.build.recipe.yaml
+++ b/Microsoft/MicrosoftWebView2EvergreenBootstrapper-Win64.build.recipe.yaml
@@ -32,26 +32,21 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 

--- a/Microsoft/MicrosoftWebView2Runtime-Win64.BMS.recipe.yaml
+++ b/Microsoft/MicrosoftWebView2Runtime-Win64.BMS.recipe.yaml
@@ -56,8 +56,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\ML_x64'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\ML_x64'
+    read_file_src_dest: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\*-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt|%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\%parsed_string%\DEV'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\MSEdgeWebView2\bms_app_integration.json'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/MicrosoftWebView2Runtime-Win64.build.recipe.yaml
+++ b/Microsoft/MicrosoftWebView2Runtime-Win64.build.recipe.yaml
@@ -32,26 +32,21 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\create-log-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\read\readme-%VENDOR%_%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%_ML\release\%VENDOR%_%NAME%%PF_STRING%_%version%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 

--- a/Microsoft/SQLServerTools2019-Win64.build.recipe.yaml
+++ b/Microsoft/SQLServerTools2019-Win64.build.recipe.yaml
@@ -35,41 +35,36 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Comment: extract the SQLServer setup
   Arguments:
     cmdline_args:
-    - /x:%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%
+    - /x:%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%\sourceunzipped\%NAME%
     - /q
     exe_file: '%pathname%'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    exe_folder: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%\sourceunzipped'
     run_elevated: 'true'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   # Arguments:
     # SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    # msi_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%-LocalDB_%PF_STRING%_%version%%LANG_STRING%.MSI'
+    destination_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%\release\%NAME%-LocalDB_%PF_STRING%_%version%%LANG_STRING%.MSI'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%\1033_ENU_LP\x64\Setup\x64\SQLLOCALDB.MSI'
+    source_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%\sourceunzipped\%NAME%\1033_ENU_LP\x64\Setup\x64\SQLLOCALDB.MSI'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%VENDOR%_%NAME%%PF_STRING%_%version%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Microsoft/Teams-Win64.BMS.recipe.yaml
+++ b/Microsoft/Teams-Win64.BMS.recipe.yaml
@@ -13,7 +13,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -48,8 +48,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\MS_Teams\%parsed_string%\ML'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\MS_Teams\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\MS_Teams\%parsed_string%\ML'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\MS_Teams\%parsed_string%\DEV'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\MS_Teams\bms_app_integration.json'
     bms_app_integration:
     - appname: 'Teams (per User)'
@@ -90,7 +90,7 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\MS_Teams\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\MS_Teams\%parsed_string%\DEV'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\MS_Teams\bms_app_integration.json'
     bms_app_integration:
     - appname: 'Teams (per Comp)'

--- a/Microsoft/Teams-Win64.build.recipe.yaml
+++ b/Microsoft/Teams-Win64.build.recipe.yaml
@@ -20,39 +20,29 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Comment: Create the build environment
   Arguments:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: helpers:release:read
-    org_ver: '%version%'
+    org_ver: '%msi_value%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::_ML'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Save an extra copy of the downloaded MSI to the release dir for the per computer install.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -60,16 +50,16 @@ Process:
   Comment: Merges the WixFirewallCA-merge.msi with the main MSI-file
   Arguments:
     mode: -m
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
-    workfile: '%BUILD_DIR%\%pkg_dir%\helpers\WixFirewallCA-merge.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
+    workfile: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\WixFirewallCA-merge.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIDbWorker
   Comment: Import the Upgrade Table into the Teams MSI-file
   Arguments:
     mode: -i
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
     workfile: Upgrade
-    workfolder: '%BUILD_DIR%\%pkg_dir%\helpers'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Comment: Set the Upgrade and Property table entries for the upgrade code in the Teams MSI-file
@@ -77,31 +67,31 @@ Process:
     SQL_command:
     - INSERT INTO `Upgrade` (`Upgrade`.`UpgradeCode`,`Upgrade`.`VersionMin`,`Upgrade`.`VersionMax`,`Upgrade`.`Attributes`, `Upgrade`.`ActionProperty`) VALUES ('{57602353-1593-497F-B8D1-6A53F86E2760}','0.0.0.0','%build_ver%',768,'UPGRADEFOUND')
     - UPDATE `Property` SET `Property`.`Value`='NETFRAMEWORK45;UPGRADEFOUND' WHERE `Property`.`Property`='SecureCustomProperties'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Apply the per Computer transform to the Teams MSI
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\teams_perComp_x64.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%-perComp%PF_STRING%_%build_ver%_ML.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\teams_perComp_x64.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Apply the per User transform to the Teams MSI
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\teams_perUser_x64.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\teams_perUser_x64.mst'
     
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Microsoft/Teams-WoS-Win64.BMS.recipe.yaml
+++ b/Microsoft/Teams-WoS-Win64.BMS.recipe.yaml
@@ -63,9 +63,9 @@ Process:
     bms_app_sharepoint:
     - SW-List-Name: '%NAME%'
       versionplatformtag: '%build_ver% ML (%PLATFORM%)'   
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
-    # icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
+    inst_file_src_dest: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    # icon_file_src: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\icons\*.*'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/Teams-WoS-Win64.build.recipe.yaml
+++ b/Microsoft/Teams-WoS-Win64.build.recipe.yaml
@@ -41,27 +41,22 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAMESHORT%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAMESHORT%%PF_STRING%_%build_ver%_ML.msix'
+    destination_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\release\%NAMESHORT%%PF_STRING%_%build_ver%_ML.msix'
     overwrite: 'true'
     source_path: '%pathname%'
     
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\read\create-log-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAMESHORT%%PF_STRING%_%build_ver%_ML\read\readme-%NAMESHORT%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Microsoft/VisualStudioCode-Win64.BMS.recipe.yaml
+++ b/Microsoft/VisualStudioCode-Win64.BMS.recipe.yaml
@@ -48,7 +48,7 @@ Process:
       </ACTION>
       </ACTIONS>
       </baramundiDeployScript>
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\VSCode_SetDisableUpdate.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\VSCode_SetDisableUpdate.bds'
 
 - Processor: FileCreator
   Comment: Generate the VSCode_UnsetDisableUpdate.bds in the release dir.
@@ -80,7 +80,7 @@ Process:
       </ACTION>
       </ACTIONS>
       </baramundiDeployScript>
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\VSCode_UnsetDisableUpdate.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\VSCode_UnsetDisableUpdate.bds'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/BMSImporter
   Comment: Import the Application into Baramundi (BMS)
@@ -129,8 +129,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*|%BMS_IMPORT_PATH_TST%\VSCode\%parsed_string%\ML'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\VSCode\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*|%BMS_IMPORT_PATH_TST%\VSCode\%parsed_string%\ML'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\VSCode\%parsed_string%\DEV'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\VSCode\bms_app_integration.json'
 
 - Processor: EndOfCheckPhase

--- a/Microsoft/VisualStudioCode-Win64.build.recipe.yaml
+++ b/Microsoft/VisualStudioCode-Win64.build.recipe.yaml
@@ -38,28 +38,23 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the VS Code install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Mindjet/MindManager-Win.download.recipe.yaml
+++ b/Mindjet/MindManager-Win.download.recipe.yaml
@@ -73,9 +73,4 @@ Process:
     - pattern: _
       repl: .
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%parsed_string%'
-    rename_var: version
-
 - Processor: EndOfCheckPhase

--- a/Mindjet/MindManager-Win64.build.recipe.yaml
+++ b/Mindjet/MindManager-Win64.build.recipe.yaml
@@ -15,34 +15,29 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: release:read
-    org_ver: '%version%'
+    org_ver: '%parsed_string%'
     pkg_dir: '%NAME%_%PF_DIGIT%_::VVeerrssiioonn::_ML'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_%PF_DIGIT%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the build dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_%PF_DIGIT%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%_%PF_DIGIT%_%build_ver%_ML\release\%NAME%_%PF_DIGIT%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%_%PF_DIGIT%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    #source_app: '%BUILD_DIR%\%NAME%_%PF_DIGIT%_%build_ver%_ML\sourcepkt\%filename%'
     source_app: '%stubpath%'
     #msi_icon_name: 'ARPPRODUCTICON.exe'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
@@ -51,13 +46,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_%PF_DIGIT%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%PF_DIGIT%_%build_ver%_ML\read\create-log-%NAME%_%PF_DIGIT%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_%PF_DIGIT%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%PF_DIGIT%_%build_ver%_ML\read\readme-%NAME%_%PF_DIGIT%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/MobaXterm/MobaXterm-Win.BMS.recipe.yaml
+++ b/MobaXterm/MobaXterm-Win.BMS.recipe.yaml
@@ -15,7 +15,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -66,7 +66,7 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/MobaXterm/MobaXterm-Win.build.recipe.yaml
+++ b/MobaXterm/MobaXterm-Win.build.recipe.yaml
@@ -49,16 +49,11 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the MobaXterm installer
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -66,36 +61,36 @@ Process:
 # - Processor: FileFinder
   # Comment: Get the the name of the extracted MSI-File.
   # Arguments:
-    # pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\*.msi'
+    # pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\*.msi'
 
 - Processor: Copier
   Comment: Copy the MobaXterm installer msi file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.MSI'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.MSI'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%found_basename%'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\%found_basename%'
 
 # - Processor: FileMover
   # Comment: Move the MobaXterm msi file to the release dir
   # Arguments:
-    # target: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.MSI'
+    # target: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.MSI'
     # source: '%found_filename%'
 
 - Processor: FileFinder
   Comment: Get the the name of the extracted DAT-File
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\*.dat'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\*.dat'
 
 # - Processor: FileMover
   # Comment: Move the MobaXterm dat file to the release dir
   # Arguments:
-    # target: '%BUILD_DIR%\%pkg_dir%\release\%found_basename%'
+    # target: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%found_basename%'
     # source: '%found_filename%'
 
 - Processor: Copier
   Comment: Copy the MobaXterm dat file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%found_basename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%found_basename%'
     overwrite: 'true'
     source_path: '%found_filename%'
 
@@ -103,40 +98,40 @@ Process:
   Comment: Merges the WixFirewallCA-merge.msi with the main MSI-file
   Arguments:
     mode: -m
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.MSI'
-    workfile: '%BUILD_DIR%\%pkg_dir%\helpers\WixFirewallCA-merge.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.MSI'
+    workfile: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\helpers\WixFirewallCA-merge.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Apply the per Computer transform to the Teams MSI
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.MSI'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\MobaXtermFW.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.MSI'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\helpers\MobaXtermFW.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.MSI'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.MSI'
     msi_icon_name: 'MobaXterm.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/Mozilla/Firefox-Win.BMS.recipe.yaml
+++ b/Mozilla/Firefox-Win.BMS.recipe.yaml
@@ -22,7 +22,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Firefox_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -86,9 +86,9 @@ Process:
     bms_username: '%BMS_USERNAME1%'
     # bms_app_dependencies:
     # - Taskkill FireFox~~~1.0~~~InstallBeforeIfNotInstalled
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Firefox_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Firefox_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Firefox_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
  
 - Processor: EndOfCheckPhase

--- a/Mozilla/Firefox-Win.build.recipe.yaml
+++ b/Mozilla/Firefox-Win.build.recipe.yaml
@@ -16,7 +16,7 @@ Process:
     PrevVerFiles: PrevVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject
-    org_ver: '%version%'
+    org_ver: '%match%'
     pkg_dir: Firefox_::VVeerrssiioonn::_ML
     recipe_cache_dir: '%RECIPE_CACHE_DIR%'
     recipe_dir: '%RECIPE_DIR%'
@@ -28,33 +28,28 @@ Process:
     file_content: '%build_ver%'
     file_path: '%RECIPE_CACHE_DIR%\version.txt'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Firefox_%build_ver%_ML
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\Firefox_%build_ver%_ML'
     build_ver: '%build_ver%'
-    org_ver: '%version%'
+    org_ver: '%match%'
     prop_file: wixproject\global.prop
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-FireFox_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\Firefox_%build_ver%_ML\read\create-log-FireFox_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-Firefox_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\Firefox_%build_ver%_ML\read\readme-Firefox_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
+    destination_path: '%BUILD_DIR%\Firefox_%build_ver%_ML\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -63,36 +58,36 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MozillaAddonIntegrator
   Comment: Integrate Addons into the install. Enable Sideloading in omni.ja
   Arguments:
-    app_build_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    app_build_path: '%BUILD_DIR%\Firefox_%build_ver%_ML\wixproject'
     application_name: Mozilla Firefox
     config_file_path: modules\AppConstants.sys.mjs
-    ext_install_path: '%BUILD_DIR%\%pkg_dir%\wixproject\Mozilla Firefox\browser\extensions'
-    ext_install_xslt: '%BUILD_DIR%\%pkg_dir%\wixproject\GUID-Preserve.xslt'
-    install_exe: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
+    ext_install_path: '%BUILD_DIR%\Firefox_%build_ver%_ML\wixproject\Mozilla Firefox\browser\extensions'
+    ext_install_xslt: '%BUILD_DIR%\Firefox_%build_ver%_ML\wixproject\GUID-Preserve.xslt'
+    install_exe: '%BUILD_DIR%\Firefox_%build_ver%_ML\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
     new_extensions:
-    - de.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/de.xpi|||ExtlpDEFiles
-    - fr.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/fr.xpi|||ExtlpFRFiles
-    - it.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/it.xpi|||ExtlpITFiles
-    - rm.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/rm.xpi|||ExtlpRMFiles
+    - de.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/de.xpi|||ExtlpDEFiles
+    - fr.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/fr.xpi|||ExtlpFRFiles
+    - it.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/it.xpi|||ExtlpITFiles
+    - rm.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/rm.xpi|||ExtlpRMFiles
     - dict-de.xpi|||https://addons.mozilla.org/firefox/downloads/latest/german-dictionary-de_ch-for-sp/|||ExtdicDEFiles
     - dict-fr.xpi|||https://addons.mozilla.org/firefox/downloads/file/3581786/|||ExtdicFRFiles
     - dict-it.xpi|||https://addons.mozilla.org/firefox/downloads/latest/dizionario-italiano/|||ExtdicITFiles
     - noscript.xpi|||https://addons.mozilla.org/firefox/downloads/latest/noscript/|||ExtNoscriptFiles
     - adblock.xpi|||https://addons.mozilla.org/firefox/downloads/latest/adblock-plus/|||ExtAdblockFiles
     omni_path: omni.ja
-    temp_path: '%BUILD_DIR%\%pkg_dir%\adm'
+    temp_path: '%BUILD_DIR%\Firefox_%build_ver%_ML\adm'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\Firefox_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\Mozilla Firefox\firefox.exe'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    source_app: '%BUILD_DIR%\Firefox_%build_ver%_ML\wixproject\Mozilla Firefox\firefox.exe'
+    # source_app: '%BUILD_DIR%\Firefox_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -100,6 +95,6 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/NANTrun
   Arguments:
-    run_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    run_folder: '%BUILD_DIR%\Firefox_%build_ver%_ML\wixproject'
 
 - Processor: EndOfCheckPhase

--- a/Mozilla/Firefox-Win.download.recipe.yaml
+++ b/Mozilla/Firefox-Win.download.recipe.yaml
@@ -19,11 +19,6 @@ Process:
     re_pattern: Firefox%20Setup%20(([0-9]+\.)*[0-9]+)
     url: '%SEARCH_URL%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%match%'
-    rename_var: version
-
 - Processor: WindowsSignatureVerifier
   Arguments:
     expected_subject: CN=Mozilla Corporation, OU=Firefox Engineering Operations, O=Mozilla Corporation, L=San Francisco, S=California, C=US
@@ -41,7 +36,7 @@ Process:
 
 - Processor: FileCreator
   Arguments:
-    file_content: '%version%'
+    file_content: '%match%'
     file_path: '%RECIPE_CACHE_DIR%\version.txt'
 
 - Processor: EndOfCheckPhase

--- a/Mozilla/Firefox-Win64.BMS.recipe.yaml
+++ b/Mozilla/Firefox-Win64.BMS.recipe.yaml
@@ -22,7 +22,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -84,9 +84,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Mozilla/Firefox-Win64.build.recipe.yaml
+++ b/Mozilla/Firefox-Win64.build.recipe.yaml
@@ -16,7 +16,7 @@ Process:
     PrevVerFiles: PrevVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject
-    org_ver: '%version%'
+    org_ver: '%match%'
     pkg_dir: Firefox_64_::VVeerrssiioonn::_ML
     recipe_cache_dir: '%RECIPE_CACHE_DIR%'
     recipe_dir: '%RECIPE_DIR%'
@@ -28,33 +28,28 @@ Process:
     file_content: '%build_ver%'
     file_path: '%RECIPE_CACHE_DIR%\version.txt'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Firefox_64_%build_ver%_ML
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\Firefox_64_%build_ver%_ML'
     build_ver: '%build_ver%'
-    org_ver: '%version%'
+    org_ver: '%match%'
     prop_file: wixproject\global.prop
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-FireFox_64_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\read\create-log-FireFox_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-Firefox_64_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\read\readme-Firefox_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
+    destination_path: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -63,36 +58,36 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MozillaAddonIntegrator
   Comment: Integrate Addons into the install. Enable Sideloading in omni.ja
   Arguments:
-    app_build_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    app_build_path: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\wixproject'
     application_name: Mozilla Firefox
     config_file_path: modules\AppConstants.sys.mjs
-    ext_install_path: '%BUILD_DIR%\%pkg_dir%\wixproject\Mozilla Firefox\browser\extensions'
-    ext_install_xslt: '%BUILD_DIR%\%pkg_dir%\wixproject\GUID-Preserve-x64.xslt'
-    install_exe: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
+    ext_install_path: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\wixproject\Mozilla Firefox\browser\extensions'
+    ext_install_xslt: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\wixproject\GUID-Preserve-x64.xslt'
+    install_exe: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
     new_extensions:
-    - de.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/de.xpi|||ExtlpDEFiles
-    - fr.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/fr.xpi|||ExtlpFRFiles
-    - it.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/it.xpi|||ExtlpITFiles
-    - rm.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%version%/win64/xpi/rm.xpi|||ExtlpRMFiles
+    - de.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/de.xpi|||ExtlpDEFiles
+    - fr.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/fr.xpi|||ExtlpFRFiles
+    - it.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/it.xpi|||ExtlpITFiles
+    - rm.xpi|||https://ftp.mozilla.org/pub/firefox/releases/%match%/win64/xpi/rm.xpi|||ExtlpRMFiles
     - dict-de.xpi|||https://addons.mozilla.org/firefox/downloads/latest/german-dictionary-de_ch-for-sp/|||ExtdicDEFiles
     - dict-fr.xpi|||https://addons.mozilla.org/firefox/downloads/file/3581786/|||ExtdicFRFiles
     - dict-it.xpi|||https://addons.mozilla.org/firefox/downloads/latest/dizionario-italiano/|||ExtdicITFiles
     - noscript.xpi|||https://addons.mozilla.org/firefox/downloads/latest/noscript/|||ExtNoscriptFiles
     - adblock.xpi|||https://addons.mozilla.org/firefox/downloads/latest/adblock-plus/|||ExtAdblockFiles
     omni_path: omni.ja
-    temp_path: '%BUILD_DIR%\%pkg_dir%\adm'
+    temp_path: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\adm'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\Mozilla Firefox\firefox.exe'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    source_app: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\wixproject\Mozilla Firefox\firefox.exe'
+    # source_app: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -100,6 +95,6 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/NANTrun
   Arguments:
-    run_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    run_folder: '%BUILD_DIR%\Firefox_64_%build_ver%_ML\wixproject'
 
 - Processor: EndOfCheckPhase

--- a/Mozilla/Thunderbird-Win64.BMS.recipe.yaml
+++ b/Mozilla/Thunderbird-Win64.BMS.recipe.yaml
@@ -19,7 +19,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\Thunderbird_64_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\release\Thunderbird_64_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -82,9 +82,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Mozilla/Thunderbird-Win64.build.recipe.yaml
+++ b/Mozilla/Thunderbird-Win64.build.recipe.yaml
@@ -34,45 +34,40 @@ Process:
     file_content: '%build_ver%'
     file_path: '%RECIPE_CACHE_DIR%\version.txt'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: Thunderbird_64_%build_ver%_ML
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%version%'
     prop_file: wixproject\global.prop
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-Thunderbird_64_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\read\create-log-Thunderbird_64_%build_ver%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-Thunderbird_64_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\read\readme-Thunderbird_64_%build_ver%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9][0-9]\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
+    destination_path: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MozillaAddonIntegrator
   Comment: Integrate Addons into the install. Enable Sideloading in omni.ja
   Arguments:
-    app_build_path: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    app_build_path: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\wixproject'
     application_name: Mozilla Thunderbird
     config_file_path: modules\AppConstants.sys.mjs
-    ext_install_path: '%BUILD_DIR%\%pkg_dir%\wixproject\Mozilla Thunderbird\extensions'
-    ext_install_xslt: '%BUILD_DIR%\%pkg_dir%\wixproject\GUID-Preserve-x64.xslt'
-    install_exe: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
+    ext_install_path: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\wixproject\Mozilla Thunderbird\extensions'
+    ext_install_xslt: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\wixproject\GUID-Preserve-x64.xslt'
+    install_exe: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\sourcepkt\%NAME%-Setup-%PLATFORM_STR%.exe'
     new_extensions:
     - de.xpi|||https://releases.mozilla.org/pub/thunderbird/releases/%version%%ESR_STRING%/linux-x86_64/xpi/de.xpi|||ExtlpDEFiles
     - fr.xpi|||https://releases.mozilla.org/pub/thunderbird/releases/%version%%ESR_STRING%/linux-x86_64/xpi/fr.xpi|||ExtlpFRFiles
@@ -93,22 +88,22 @@ Process:
     - CompactHeader.xpi|||%INTERNAL_EXT_URL%/compact_headers-latest.xpi|||ExtCompactHeaderFiles
     - LookOut.xpi|||%INTERNAL_EXT_URL%/lookout_fix_version-latest.xpi|||ExtLookOutFiles
     omni_path: omni.ja
-    temp_path: '%BUILD_DIR%\%pkg_dir%\adm'
+    temp_path: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\adm'
     #- sieve.xpi|||https://polybox.ethz.ch/index.php/s/G6e4OKrKqIBk3LR/download|||ExtSieveFiles
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\Mozilla Thunderbird\thunderbird.exe'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    source_app: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\wixproject\Mozilla Thunderbird\thunderbird.exe'
+    # source_app: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -116,6 +111,6 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/NANTrun
   Arguments:
-    run_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    run_folder: '%BUILD_DIR%\Thunderbird_64_%build_ver%_ML\wixproject'
 
 - Processor: EndOfCheckPhase

--- a/NVM/NVM-Win64.build.recipe.yaml
+++ b/NVM/NVM-Win64.build.recipe.yaml
@@ -26,17 +26,12 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the GIMP install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -44,19 +39,19 @@ Process:
   # Comment: Extract the GIMP installer
   # Arguments:
     # inno_path: '%pathname%'
-    # workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    # workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     # # inno_compiler: '*'
     # ignore_errors: False
 
 # - Processor: FileFinder
   # Comment: Get the GIMP exe file to extract the icons from
   # Arguments:
-    # pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\bin\gimp-console-*.exe'
+    # pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\{app}\bin\gimp-console-*.exe'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the NVM icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -71,12 +66,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/NXLog/NXLog-CE-Win64.build.recipe.yaml
+++ b/NXLog/NXLog-CE-Win64.build.recipe.yaml
@@ -23,34 +23,29 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Git install exe file to the sourceunzipped dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%%PF_STRING%_%version%_ML.MSI'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\%NAME%%PF_STRING%_%version%_ML.MSI'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Copy the MSI-file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%%PF_STRING%_%version%_ML.MSI'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\%NAME%%PF_STRING%_%version%_ML.MSI'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/NoMachine/NoMachineEnterpriseClient-Win64.BMS.recipe.yaml
+++ b/NoMachine/NoMachineEnterpriseClient-Win64.BMS.recipe.yaml
@@ -68,9 +68,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\ML_x64'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\ML_x64'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/NoMachine/NoMachineEnterpriseClient-Win64.build.recipe.yaml
+++ b/NoMachine/NoMachineEnterpriseClient-Win64.build.recipe.yaml
@@ -19,33 +19,23 @@ Process:
     - pattern: _
       repl: '.'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%parsed_string%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Comment: Create a build enviroment to store the package
   Arguments:
-    version: '%version%'
+    version: '%parsed_string%'
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: helpers:sourceunzipped:release:read
-    org_ver: '%version%'
+    org_ver: '%parsed_string%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::_ML'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the NoMachineEnterpriseClient installer file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -53,20 +43,20 @@ Process:
   Comment: Extract the NoMachine installer
   Arguments:
     inno_path: '%pathname%'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\sourceunzipped\'
     # inno_compiler: '*'
     ignore_errors: False
    
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\bin\nxplayer.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\sourceunzipped\{app}\bin\nxplayer.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -74,14 +64,14 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\read\create-log-%NAME%%PF_STRING%_%parsed_string%_ML.txt'
+    new_ver: '%parsed_string%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
-    new_ver: '%version%'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%parsed_string%_ML\read\readme-%NAME%%PF_STRING%_%parsed_string%_ML.txt'
+    new_ver: '%parsed_string%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps

--- a/NotepadPlusPlus/NotepadPlusPlus-Win64.BMS.recipe.yaml
+++ b/NotepadPlusPlus/NotepadPlusPlus-Win64.BMS.recipe.yaml
@@ -13,7 +13,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -75,9 +75,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/NotepadPlusPlus/NotepadPlusPlus-Win64.build.recipe.yaml
+++ b/NotepadPlusPlus/NotepadPlusPlus-Win64.build.recipe.yaml
@@ -25,30 +25,25 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Notepad++ installer exe file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%.exe'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%.exe'
 
 - Processor: Copier
   Comment: Copy the Notepad++ installer zip file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.zip'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Notepad++ installer
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -56,8 +51,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Notepad++ installer
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\contextMenu'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%.exe'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\contextMenu'
     extract_file: '*\NppShell.*'
     ignore_pattern: ''
     preserve_paths: 'False'
@@ -65,15 +60,15 @@ Process:
 - Processor: Copier
   Comment: Copy the Notepad++ updater to outside of the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\updater'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\updater'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\updater'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\updater'
 
 - Processor: PathDeleter
   Comment: Delete the updater files from the build dir
   Arguments:
     path_list:
-    - '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\updater'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\updater'
 
 - Processor: URLTextSearcher
   Arguments:
@@ -88,14 +83,14 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     extract_file: '*\pl.x64.json'
     preserve_paths: 'False'
     recursive: 'True'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/TextFileSearcher
   Arguments:
-    file_to_open: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\pl.x64.json'
+    file_to_open: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\pl.x64.json'
     re_pattern: https://github.com/.*/compare-plugin/releases/download/v[0-9.]+/ComparePlugin_v[0-9.]+_X64.zip
 
 - Processor: URLDownloader
@@ -107,14 +102,14 @@ Process:
   Comment: Extract the Notepad++ installer
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\plugins\ComparePlugin'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\plugins\ComparePlugin'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'False'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/TextFileSearcher
   Arguments:
-    file_to_open: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\pl.x64.json'
+    file_to_open: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\pl.x64.json'
     re_pattern: https://sourceforge.net/.*/JSToolNPP[0-9.]+uni.64.zip
 
 - Processor: URLDownloader
@@ -126,7 +121,7 @@ Process:
   Comment: Extract the Notepad++ installer
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\plugins\JSMinNPP'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\plugins\JSMinNPP'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'False'
@@ -137,35 +132,30 @@ Process:
     github_repo: chcg/NPP_HexEdit
     include_prereleases: 'true'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: https://github.com/chcg/NPP_HexEdit/releases/download/%version%/HexEditor_%version%_x64.zip
-    rename_var: hexplugin_url
-
 - Processor: URLDownloader
   Arguments:
     filename: hexeditplugin.zip
-    url: '%hexplugin_url%'
+    url: 'https://github.com/chcg/NPP_HexEdit/releases/download/%version%/HexEditor_%version%_x64.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the Notepad++ installer
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\plugins\HexEditor'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\plugins\HexEditor'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'False'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%NAME%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -174,8 +164,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the Notepad++ res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%NAME%.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%NAME%.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,100,'
     # ignore_errors: 'True'
@@ -183,38 +173,38 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Notepad++
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,100,'
     # ignore_errors: 'True'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Notepad++ MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%
     build_target: WIX
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
@@ -224,6 +214,6 @@ Process:
     # - UPDATE `DuplicateFile` SET `DuplicateFile`.`File_`='config.xml' WHERE `DuplicateFile`.`FileKey`='DupFile1'
     # - DELETE FROM `File` WHERE `File`.`File`='config_xml'
     # - DELETE FROM `MsiFileHash` WHERE `MsiFileHash`.`File_`='config_xml'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps

--- a/OBS/OBS-Studio-Win64.build.recipe.yaml
+++ b/OBS/OBS-Studio-Win64.build.recipe.yaml
@@ -22,39 +22,34 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the OBS-Studio install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the OBS-Studio executable
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     extract_file: 'bin\64bit\obs64.exe'
     ignore_pattern: ''
     preserve_paths: 'False'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: bl
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\obs64.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\obs64.exe'
     # msi_icon_name: 'ProductIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -62,12 +57,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Oracle/OracleInstantClient-Win.BMS.recipe.yaml
+++ b/Oracle/OracleInstantClient-Win.BMS.recipe.yaml
@@ -23,7 +23,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -76,9 +76,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Oracle/OracleInstantClient-Win.build.recipe.yaml
+++ b/Oracle/OracleInstantClient-Win.build.recipe.yaml
@@ -30,24 +30,19 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Eclipse installer files to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.zip'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%.zip'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -62,15 +57,15 @@ Process:
 - Processor: URLDownloader
   Arguments:
     #filename: '%NAME%-odbc.zip'
-    filename: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-odbc.zip'
+    filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-odbc.zip'
     url: 'https:%match%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-odbc.zip'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-odbc.zip'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -84,15 +79,15 @@ Process:
 - Processor: URLDownloader
   Arguments:
     #filename: '%NAME%-sqlplus.zip'
-    filename: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-sqlplus.zip'
+    filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-sqlplus.zip'
     url: 'https:%match%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-sqlplus.zip'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-sqlplus.zip'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -106,15 +101,15 @@ Process:
 - Processor: URLDownloader
   Arguments:
     #filename: '%NAME%-tools.zip'
-    filename: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-tools.zip'
+    filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-tools.zip'
     url: 'https:%match%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-tools.zip'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-tools.zip'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -122,34 +117,34 @@ Process:
 - Processor: FileMover
   Comment: Rename the installer folder to the final application dir
   Arguments:
-    target: '%BUILD_DIR%\%pkg_dir%\wixproject\%APPFOLDER%_%MAJOR_VERSION%\'
-    source: '%BUILD_DIR%\%pkg_dir%\wixproject\instantclient_%MAJOR_VERSION%_%MINOR_VERSION%\'
+    target: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%APPFOLDER%_%MAJOR_VERSION%\'
+    source: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\instantclient_%MAJOR_VERSION%_%MINOR_VERSION%\'
 
 # - Processor: Copier
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\%APPFOLDER%_%MAJOR_VERSION%\network\admin'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%APPFOLDER%_%MAJOR_VERSION%\network\admin'
     # overwrite: 'true'
-    # source_path: '%BUILD_DIR%\%pkg_dir%\helpers\*.zip'
+    # source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\*.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\orafiles.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%APPFOLDER%_%MAJOR_VERSION%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\orafiles.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%APPFOLDER%_%MAJOR_VERSION%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 # - Processor: com.github.haircut.processors/AppIconExtractor
   # Arguments:
-    # ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    # ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     # icon_file_number: 0
     # # composite_padding: 20
     # # composite_position: ul
     # # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # # composite_uninstall_template: /Users/haircut/Documents/delete.png
     # icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\Eclipse-Java\eclipse.exe'
+    # source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\Eclipse-Java\eclipse.exe'
     # #msi_icon_name: 'MainExecutableIcon.ico'
     # composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     # composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -157,28 +152,28 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Eclipse MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%APPFOLDER%_%MAJOR_VERSION%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%;InstallFolder=%APPFOLDER%_%MAJOR_VERSION%
-    #build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%APPFOLDER%_%MAJOR_VERSION%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%;InstallFolder=%APPFOLDER%_%MAJOR_VERSION%
+    #build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX

--- a/Oracle/OracleInstantClient-Win64.BMS.recipe.yaml
+++ b/Oracle/OracleInstantClient-Win64.BMS.recipe.yaml
@@ -24,7 +24,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -77,9 +77,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Oracle/OracleInstantClient-Win64.build.recipe.yaml
+++ b/Oracle/OracleInstantClient-Win64.build.recipe.yaml
@@ -32,23 +32,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Eclipse installer files to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.zip'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%.zip'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the InstantClient main zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -62,14 +57,14 @@ Process:
 
 - Processor: URLDownloader
   Arguments:
-    filename: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-odbc.zip'
+    filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-odbc.zip'
     url: 'https:%match%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the InstantClient odbc zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-odbc.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-odbc.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -82,14 +77,14 @@ Process:
 
 - Processor: URLDownloader
   Arguments:
-    filename: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-sqlplus.zip'
+    filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-sqlplus.zip'
     url: 'https:%match%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the InstantClient sqlplus zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-sqlplus.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-sqlplus.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -102,14 +97,14 @@ Process:
 
 - Processor: URLDownloader
   Arguments:
-    filename: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-tools.zip'
+    filename: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-tools.zip'
     url: 'https:%match%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the InstantClient tools zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%-tools.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%-tools.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -117,41 +112,41 @@ Process:
 - Processor: FileMover
   Comment: Rename the installer folder to the final application dir
   Arguments:
-    target: '%BUILD_DIR%\%pkg_dir%\wixproject\%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%\'
-    source: '%BUILD_DIR%\%pkg_dir%\wixproject\instantclient_%MAJOR_VERSION%_%MINOR_VERSION%\'
+    target: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%\'
+    source: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\instantclient_%MAJOR_VERSION%_%MINOR_VERSION%\'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the zip archive with the config files.
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\orafiles.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\orafiles.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the Eclipse MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%;InstallFolder=%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%;InstallFolder=%APPFOLDER%%PF_STRING%_%MAJOR_VERSION%
     build_target: WIX

--- a/Oracle/SqlDeveloper-Win64.BMS.recipe.yaml
+++ b/Oracle/SqlDeveloper-Win64.BMS.recipe.yaml
@@ -14,7 +14,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -66,8 +66,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER3%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Oracle/SqlDeveloper-Win64.build.recipe.yaml
+++ b/Oracle/SqlDeveloper-Win64.build.recipe.yaml
@@ -23,43 +23,38 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Element installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.zip'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%.zip'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%.zip'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the SqlDeveloper zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%NAME%.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
@@ -68,23 +63,23 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the SqlDeveloper MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\SqlDeveloper.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\SqlDeveloper.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\%NAME%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the SQL Dev icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Resources\SqlDeveloper.ico'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\%NAME%\Resources\SqlDeveloper.ico'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     msi_icon_name: 'SqlDeveloperIcon.exe'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'

--- a/PDF24/PDF24-Creator-Win64.BMS.recipe.yaml
+++ b/PDF24/PDF24-Creator-Win64.BMS.recipe.yaml
@@ -18,7 +18,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -95,9 +95,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/PDF24/PDF24-Creator-Win64.build.recipe.yaml
+++ b/PDF24/PDF24-Creator-Win64.build.recipe.yaml
@@ -27,30 +27,25 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Save a copy of the corporate MST to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\PDF24_Enterprise_byAutoPkg.mst'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\PDF24_Enterprise_byAutoPkg.mst'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\helpers\PDF24_Enterprise_byAutoPkg.mst'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\PDF24_Enterprise_byAutoPkg.mst'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   # Comment: Extract the InstantClient odbc zip archive
   # Arguments:
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    # exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     # extract_file: 'putty.cab'
     # ignore_pattern: ''
     # preserve_paths: 'False'
@@ -58,15 +53,15 @@ Process:
 # - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   # Comment: Extract the InstantClient odbc zip archive
   # Arguments:
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\putty.cab'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    # exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\putty.cab'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     # extract_file: 'PuTTY_File'
     # ignore_pattern: ''
     # preserve_paths: 'False'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -81,13 +76,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Plotsoft/PDFill-Free-Win64.build.recipe.yaml
+++ b/Plotsoft/PDFill-Free-Win64.build.recipe.yaml
@@ -34,15 +34,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the Endnote installer file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -50,13 +45,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Prusa/PrusaSlicerStandalone-Win64.build.recipe.yaml
+++ b/Prusa/PrusaSlicerStandalone-Win64.build.recipe.yaml
@@ -36,17 +36,12 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the Prusa Slicer Standalone install exe file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -56,19 +51,19 @@ Process:
     # cmdline_args:
     # - /exenoui
     # - /extract
-    # - '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    # - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
     # exe_file: '%pathname%'
-    # exe_folder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    # exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
     # run_elevated: 'true'
 
 # - Processor: FileFinder
   # Arguments:
-    # pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\*.msi'
+    # pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\*.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the GIMP icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -83,12 +78,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/PuTTY/PuTTY-Win64.BMS.recipe.yaml
+++ b/PuTTY/PuTTY-Win64.BMS.recipe.yaml
@@ -14,7 +14,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_EN.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\release\%NAME%%PF_STRING%_%build_ver%_EN.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -92,9 +92,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\EN'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\EN'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/PuTTY/PuTTY-Win64.build.recipe.yaml
+++ b/PuTTY/PuTTY-Win64.build.recipe.yaml
@@ -25,23 +25,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '2'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_EN'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_EN.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\release\%NAME%%PF_STRING%_%build_ver%_EN.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   # Comment: Extract the InstantClient odbc zip archive
   # Arguments:
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_EN.msi'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    # exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\release\%NAME%%PF_STRING%_%build_ver%_EN.msi'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\sourceunzipped\'
     # extract_file: 'putty.cab'
     # ignore_pattern: ''
     # preserve_paths: 'False'
@@ -49,22 +44,22 @@ Process:
 # - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   # Comment: Extract the InstantClient odbc zip archive
   # Arguments:
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\putty.cab'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    # exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\sourceunzipped\putty.cab'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\sourceunzipped\'
     # extract_file: 'PuTTY_File'
     # ignore_pattern: ''
     # preserve_paths: 'False'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\PuTTY_256.ico'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\helpers\PuTTY_256.ico'
     # msi_icon_name: 'installericon.exe'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -72,13 +67,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_EN.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\read\create-log-%NAME%%PF_STRING%_%build_ver%_EN.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_EN.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_EN\read\readme-%NAME%%PF_STRING%_%build_ver%_EN.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/PyMOL/PyMOL-Win64.build.recipe.yaml
+++ b/PyMOL/PyMOL-Win64.build.recipe.yaml
@@ -27,21 +27,16 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
     overwrite: 'true'
     source_path: '%pathname%'
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.exe'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from Telegraf
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -56,13 +51,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Python/Python-Win64.build.recipe.yaml
+++ b/Python/Python-Win64.build.recipe.yaml
@@ -23,30 +23,25 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_%LANG_STR%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the Python install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_%LANG_STR%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_%LANG_STR%\release\%NAME%%PF_STRING%_%build_ver%_%LANG_STR%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_%LANG_STR%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\python_256.ico'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_%LANG_STR%\helpers\python_256.ico'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -54,12 +49,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_%LANG_STR%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_%LANG_STR%\read\create-log-%NAME%%PF_STRING%_%build_ver%_%LANG_STR%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_%LANG_STR%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_%LANG_STR%\read\readme-%NAME%%PF_STRING%_%build_ver%_%LANG_STR%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/QGIS/QGIS-Win64.build.recipe.yaml
+++ b/QGIS/QGIS-Win64.build.recipe.yaml
@@ -23,34 +23,29 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 # - Processor: Copier
   # Comment: Copy the MSI-file to the sourceunzipped dir
   # Arguments:
-    # destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%%PF_STRING%_%version%_raw.msi'
+    # destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\%NAME%%PF_STRING%_%version%_raw.msi'
     # overwrite: 'true'
     # source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Copy the MSI-file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -60,9 +55,9 @@ Process:
   # Comment: Applies the transforms to the MSI-file in the release folder
   # Arguments:
     # mode: -a
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     # mst_paths:
-    # - '%BUILD_DIR%\%pkg_dir%\helpers\KPXC-UserSettings-02.mst'
+    # - '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\helpers\KPXC-UserSettings-02.mst'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   # Arguments:
@@ -70,18 +65,18 @@ Process:
       # /j: KeePassXC %version%
       # /o: Slightely altered (AutoUpdate disabled). %us_date% by AutoPkg
       # /t: KeePassXC %version%
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\qgis-icon-512x512.png'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\helpers\qgis-icon-512x512.png'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'

--- a/RStudio/RStudio-Win64.build.recipe.yaml
+++ b/RStudio/RStudio-Win64.build.recipe.yaml
@@ -20,29 +20,24 @@ Process:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourcepkt:sourceunzipped:release:read:helpers:wixproject:wixproject\RStudio:wixproject\Includes:wixproject\Resources:wixproject\Lang:wixproject\Fragments
-    org_ver: '%version%'
+    org_ver: '%versionraw%.%buildraw%'
     pkg_dir: '%NAME%%PF_STRING%_::VVeerrssiioonn::%LANG_STRING%'
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the RStudio installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\RStudio'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourcepkt\%filename%'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\RStudio'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -51,31 +46,31 @@ Process:
   Comment: Delete unnesessary folders from the RStudio installer files
   Arguments:
     path_list:
-    - '%BUILD_DIR%\%pkg_dir%\wixproject\RStudio\$PLUGINSDIR'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\RStudio\$PLUGINSDIR'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\RStudio\rstudio.exe'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\RStudio\rstudio.exe'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%versionraw%.%buildraw%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -84,8 +79,8 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Extract the RStudio res file
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\wixproject\RStudio\rstudio.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\RStudio\rstudio.exe'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -93,9 +88,9 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for RStudio
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\wixproject\Resources\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\Resources\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -103,16 +98,16 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the RStudio MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\RStudio.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;RStudioDir=%BUILD_DIR%\%pkg_dir%\wixproject\RStudio;version=%version%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\RStudio.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject;RStudioDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\wixproject\RStudio;version=%versionraw%.%buildraw%
     build_target: WIX
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps

--- a/RStudio/RStudio-Win64.download.recipe.yaml
+++ b/RStudio/RStudio-Win64.download.recipe.yaml
@@ -24,9 +24,4 @@ Process:
     expected_subject: CN="Posit Software, PBC", O="Posit Software, PBC", L=Boston, S=Massachusetts, C=US
     input_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%versionraw%.%buildraw%'
-    rename_var: version
-
 - Processor: EndOfCheckPhase

--- a/SEH/UTN_Manager-Win.BMS.recipe.yaml
+++ b/SEH/UTN_Manager-Win.BMS.recipe.yaml
@@ -48,9 +48,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
-    # icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    # icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
     #json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/SEH/UTN_Manager-Win.build.recipe.yaml
+++ b/SEH/UTN_Manager-Win.build.recipe.yaml
@@ -23,29 +23,24 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the UTN_Manager zip file to the sourcepkt dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%%PF_STRING%_%build_ver%_ML.zip'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%%PF_STRING%_%build_ver%_ML.zip'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%NAME%%PF_STRING%_%build_ver%_ML.zip'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%NAME%%PF_STRING%_%build_ver%_ML.zip'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     extract_file: sehutnmanager-win-*.exe
     preserve_paths: 'false'
     recursive: 'true'
 
 - Processor: FileFinder
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\sehutnmanager-win-*.exe'
+    pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\sehutnmanager-win-*.exe'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
@@ -57,18 +52,18 @@ Process:
 - Processor: Copier
   Comment: Copy the UTN_Manager install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%found_filename%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/SafeExamBrowser/SafeExamBrowser-Win64.build.recipe.yaml
+++ b/SafeExamBrowser/SafeExamBrowser-Win64.build.recipe.yaml
@@ -22,15 +22,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the SEB installer files to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -39,7 +34,7 @@ Process:
   # Arguments:
     # archive_type: '#'
     # exe_path: '%pathname%'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped'
     # extract_file: 4.cab
     # ignore_pattern: ''
     # preserve_paths: 'False'
@@ -48,8 +43,8 @@ Process:
   # Comment: Extract the SafeExamBrowser setup exe
   # Arguments:
     # archive_type: '*'
-    # exe_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\4.cab'
-    # extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    # exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\4.cab'
+    # extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped'
     # extract_file: a0
     # ignore_pattern: ''
     # preserve_paths: 'False'
@@ -58,25 +53,25 @@ Process:
   # Comment: Move the SafeExamBrowser x64 MSI file to the release dir
   # Arguments:
     # overwrite: 'true'
-    # source: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\a0'
-    # target: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    # source: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\a0'
+    # target: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Applies the Settings-Transform to the SafeExamBrowser.msi to the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\SEB_Uninst-log-Rem-Chng-Add-SC.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\SEB_Uninst-log-Rem-Chng-Add-SC.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Scribus/Scribus-Win64.BMS.recipe.yaml
+++ b/Scribus/Scribus-Win64.BMS.recipe.yaml
@@ -69,7 +69,7 @@ Process:
       </ACTION>
       </ACTIONS>
       </baramundiDeployScript>
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\i_%NAME%%PF_STRING%_%build_ver%.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\i_%NAME%%PF_STRING%_%build_ver%.bds'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/BMSImporter
   Comment: Import the Application into Baramundi (BMS)
@@ -114,9 +114,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons\*.*'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Scribus/Scribus-Win64.build.recipe.yaml
+++ b/Scribus/Scribus-Win64.build.recipe.yaml
@@ -23,34 +23,29 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the EXE-file to the sourceunzipped dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%%PF_STRING%_%version%_raw.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\%NAME%%PF_STRING%_%version%_raw.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Copy the EXE-file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -59,21 +54,21 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\'
     # extract_file: 'bin\gswin64.exe'
     extract_file: '%NAME%.exe'
     preserve_paths: 'False'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\sourceunzipped\%NAME%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/SecureCRT/SecureCRT-Win64.build.recipe.yaml
+++ b/SecureCRT/SecureCRT-Win64.build.recipe.yaml
@@ -20,17 +20,12 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_64_%version%_EN'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/ExecuteFile
   Arguments:
     cmdline_args:
     - /s
     - /x
-    - /b%BUILD_DIR%\%pkg_dir%\sourceunzipped
+    - /b%BUILD_DIR%\%NAME%_64_%version%_EN\sourceunzipped
     - /v"/qn"
     exe_file: '%pathname%'
     exe_folder: '%RECIPE_CACHE_DIR%\downloads'
@@ -39,31 +34,31 @@ Process:
 - Processor: FileFinder
   Comment: Get the filename of the extracted MSI file
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\VanDyke*.msi'
+    pattern: '%BUILD_DIR%\%NAME%_64_%version%_EN\sourceunzipped\VanDyke*.msi'
 
 - Processor: FileMover
   Comment: Move the MSI file to the release dir.
   Arguments:
     overwrite: 'true'
     source: '%found_filename%'
-    target: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_64_%build_ver%_EN.msi'
+    target: '%BUILD_DIR%\%NAME%_64_%version%_EN\release\%NAME%_64_%build_ver%_EN.msi'
 
 - Processor: Copier
   Comment: Save a copy of the downloaded ZIP to the build dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%version%_EN\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-SecureCRT_64_%build_ver%_EN.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%version%_EN\read\create-log-SecureCRT_64_%build_ver%_EN.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-SecureCRT_64_%build_ver%_EN.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%version%_EN\read\readme-SecureCRT_64_%build_ver%_EN.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Serif/AffinityDesigner-Win64.BMS.recipe.yaml
+++ b/Serif/AffinityDesigner-Win64.BMS.recipe.yaml
@@ -19,7 +19,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%pkg_dir%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -75,8 +75,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Serif/AffinityDesigner-Win64.build.recipe.yaml
+++ b/Serif/AffinityDesigner-Win64.build.recipe.yaml
@@ -25,60 +25,55 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_64_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    exe_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     extract_cmd: BIN,135,
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped'
     extract_file: affinity-%AppKey%.msi
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    exe_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     extract_cmd: ICONGROUP,107,
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped'
     extract_file: affinity-%AppKey%.ico
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%pkg_dir%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\create-log-%NAME%_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%pkg_dir%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\readme-%NAME%_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\affinity-%AppKey%.msi'
+    source_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped\affinity-%AppKey%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     msi_icon_name: 'MyARPIcon'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -93,7 +88,7 @@ Process:
     # - INSERT INTO `Property` (`Property`.`Property`,`Property`.`Value`) VALUES ('INSTALL_DESKTOP_SHORTCUT_PROPERTY','#0')
     # - UPDATE `Property` SET `Property`.`Value`='#1' WHERE `Property`.`Property`='NO_UPDATE_CHECK_PROPERTY'
     # - UPDATE `Property` SET `Property`.`Value`='#1' WHERE `Property`.`Property`='NO_EULA_PROPERTY'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   # Arguments:
@@ -102,6 +97,6 @@ Process:
       # /o: Version %version% for ETHZ ID. %us_date% by AutoPkg
       # /p: x64;1033
       # /t: '%NAME% x64 %version% ML'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%pkg_dir%.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Serif/AffinityPhoto-Win64.BMS.recipe.yaml
+++ b/Serif/AffinityPhoto-Win64.BMS.recipe.yaml
@@ -19,7 +19,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%pkg_dir%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -76,8 +76,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Serif/AffinityPhoto-Win64.build.recipe.yaml
+++ b/Serif/AffinityPhoto-Win64.build.recipe.yaml
@@ -25,60 +25,55 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_64_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    exe_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     extract_cmd: BIN,135,
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped'
     extract_file: affinity-%AppKey%.msi
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    exe_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     extract_cmd: ICONGROUP,107,
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped'
     extract_file: affinity-%AppKey%.ico
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%pkg_dir%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\create-log-%NAME%_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%pkg_dir%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\readme-%NAME%_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\affinity-%AppKey%.msi'
+    source_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped\affinity-%AppKey%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     msi_icon_name: 'MyARPIcon'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -93,7 +88,7 @@ Process:
     - INSERT INTO `Property` (`Property`.`Property`,`Property`.`Value`) VALUES ('INSTALL_DESKTOP_SHORTCUT_PROPERTY','#0')
     - UPDATE `Property` SET `Property`.`Value`='#1' WHERE `Property`.`Property`='NO_UPDATE_CHECK_PROPERTY'
     - UPDATE `Property` SET `Property`.`Value`='#1' WHERE `Property`.`Property`='NO_EULA_PROPERTY'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   Arguments:
@@ -102,6 +97,6 @@ Process:
       /o: Version %version% for ETHZ ID. %us_date% by AutoPkg
       /p: x64;1033
       /t: '%NAME% x64 %version% ML'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%pkg_dir%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Serif/AffinityPublisher-Win64.BMS.recipe.yaml
+++ b/Serif/AffinityPublisher-Win64.BMS.recipe.yaml
@@ -19,7 +19,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%pkg_dir%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -76,8 +76,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Serif/AffinityPublisher-Win64.build.recipe.yaml
+++ b/Serif/AffinityPublisher-Win64.build.recipe.yaml
@@ -25,60 +25,55 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_64_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    exe_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     extract_cmd: BIN,135,
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped'
     extract_file: affinity-%AppKey%.msi
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceExtractor
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\affinity-%AppKey%.exe'
+    exe_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\affinity-%AppKey%.exe'
     extract_cmd: ICONGROUP,107,
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped'
     extract_file: affinity-%AppKey%.ico
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%pkg_dir%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\create-log-%NAME%_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%pkg_dir%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\read\readme-%NAME%_64_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\affinity-%AppKey%.msi'
+    source_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourceunzipped\affinity-%AppKey%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\sourcepkt\%filename%'
+    source_app: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%%PF_STRING%_%version%%LANG_STRING%.msi'
     msi_icon_name: 'MyARPIcon'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -93,7 +88,7 @@ Process:
     # - INSERT INTO `Property` (`Property`.`Property`,`Property`.`Value`) VALUES ('INSTALL_DESKTOP_SHORTCUT_PROPERTY','#0')
     # - UPDATE `Property` SET `Property`.`Value`='#1' WHERE `Property`.`Property`='NO_UPDATE_CHECK_PROPERTY'
     # - UPDATE `Property` SET `Property`.`Value`='#1' WHERE `Property`.`Property`='NO_EULA_PROPERTY'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%pkg_dir%.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/MSIApplySumInfo
   # Arguments:
@@ -102,6 +97,6 @@ Process:
       # /o: Version %version% for ETHZ ID. %us_date% by AutoPkg
       # /p: x64;1033
       # /t: '%NAME% x64 %version% ML'
-    # msi_path: '%BUILD_DIR%\%pkg_dir%\release\%pkg_dir%.msi'
+    # msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%_ML\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/Slack/Slack-Win64.build.recipe.yaml
+++ b/Slack/Slack-Win64.build.recipe.yaml
@@ -22,11 +22,6 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: URLDownloader
   Arguments:
     CHECK_FILESIZE_ONLY: false
@@ -36,19 +31,19 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%_%PLATFORM%.msi'
 
@@ -60,11 +55,11 @@ Process:
     - INSERT INTO `Property` (`Property`.`Property`,`Property`.`Value`) VALUES ('ARPPRODUCTICON','SlackIcon.exe')
     - DELETE FROM `Property` WHERE `Property`.`Property`='ARPSYSTEMCOMPONENT'
     - UPDATE `Component` SET `Component`.`Condition`='DESKTOPSC=1' WHERE `Component`.`Component`='DesktopShortcut'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -72,7 +67,7 @@ Process:
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
     source_app: '%RECIPE_CACHE_DIR%\downloads\%NAME%_%PLATFORM%.exe'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    # source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -82,7 +77,7 @@ Process:
   Comment: Extract the Eclipse res file
   Arguments:
     exe_path: '%RECIPE_CACHE_DIR%\downloads\%NAME%_%PLATFORM%.exe'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Icon-%NAME%.res'
     reswork_action: 'extract'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
@@ -90,26 +85,26 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/ResourceWorker
   Comment: Generate a new Icon.exe file for Eclipse-Java
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\helpers\Icon-Stub-1.exe'
-    input_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon-%NAME%.res'
-    output_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Main-Icon.exe'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Icon-Stub-1.exe'
+    input_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Icon-%NAME%.res'
+    output_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Main-Icon.exe'
     reswork_action: 'add'
     reswork_cmd: 'ICONGROUP,,'
     # ignore_errors: 'True'
 
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Icon\SlackIcon.exe.ibd'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Icon\SlackIcon.exe.ibd'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\Main-Icon.exe'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\Main-Icon.exe'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIDbWorker
   Comment: Merges the Icon with the main MSI-file
   Arguments:
     mode: -i
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     workfile: 'Icon.idt'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
@@ -119,6 +114,6 @@ Process:
       /j: '%NAME%'
       /o: Version %version%, %us_date% by AutoPkg
       /t: '%NAME% %version% ML'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/SumatraPDF/SumatraPDF-Win64.build.recipe.yaml
+++ b/SumatraPDF/SumatraPDF-Win64.build.recipe.yaml
@@ -24,24 +24,19 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the SumatraPDF install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML-install.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML-install.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the SumatraPDF icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -56,12 +51,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Teclib/GLPI-Agent-Win64.build.recipe.yaml
+++ b/Teclib/GLPI-Agent-Win64.build.recipe.yaml
@@ -37,17 +37,12 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the GLPI-Agent install msi file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -55,7 +50,7 @@ Process:
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the GIT icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -70,12 +65,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Tenable/Nessus-Agent-Win64.BMS.recipe.yaml
+++ b/Tenable/Nessus-Agent-Win64.BMS.recipe.yaml
@@ -17,7 +17,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -136,7 +136,7 @@ Process:
       </ACTION>
       </ACTIONS>
       </baramundiDeployScript>
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\i_%NAME%%PF_STRING%_%build_ver%.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\i_%NAME%%PF_STRING%_%build_ver%.bds'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -191,8 +191,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML_x64'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/Tenable/Nessus-Agent-Win64.build.recipe.yaml
+++ b/Tenable/Nessus-Agent-Win64.build.recipe.yaml
@@ -23,27 +23,22 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%version%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the MSI-file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%version%_ML.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\release\%NAME%%PF_STRING%_%version%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\create-log-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%version%_ML\read\readme-%NAME%%PF_STRING%_%version%_ML.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/TexStudio/TexStudio-Win64.build.recipe.yaml
+++ b/TexStudio/TexStudio-Win64.build.recipe.yaml
@@ -25,15 +25,10 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Copy the TexStudio installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%RECIPE_CACHE_DIR%\downloads\%filename%'
 
@@ -42,59 +37,59 @@ Process:
   Arguments:
     cmdline_args:
     - /S
-    - /D=%BUILD_DIR%\%pkg_dir%\sourceunzipped
-    exe_file: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourcepkt'
+    - /D=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped
+    exe_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt'
     run_elevated: true
 
 - Processor: Copier
   Comment: Copy the TexStudio installer file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\wixproject\TexStudio\'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\TexStudio\'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    source_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/WixDefaults
   Comment: Set the actual version strings to the version.wxi file
   Arguments:
-    build_dir: '%BUILD_DIR%\%pkg_dir%'
+    build_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML'
     build_ver: '%build_ver%'
     org_ver: '%build_ver%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the TexStudio MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\TexStudio.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;TexStudioDir=%BUILD_DIR%\%pkg_dir%\wixproject\TexStudio;version=%version%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\TexStudio.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;TexStudioDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\TexStudio;version=%version%
     build_target: WIX
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the TexStudio icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\Resources\SqlDeveloper.ico'
-    source_app: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\Resources\SqlDeveloper.ico'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     msi_icon_name: 'TeXstudio.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -106,6 +101,6 @@ Process:
   Arguments:
     cmdline_args:
     - /S
-    - _?=%BUILD_DIR%\%pkg_dir%\sourceunzipped
-    exe_file: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\uninstall.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    - _?=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped
+    exe_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\uninstall.exe'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'

--- a/VLC/VLC-Win64.BMS.recipe.yaml
+++ b/VLC/VLC-Win64.BMS.recipe.yaml
@@ -20,7 +20,7 @@ Process:
   Comment: Get the ProductCode into the  msi_value variable for the BMS uninstall string
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Comment: Exchange "." for "_" on build_ver variable for BMS-DIP-path
@@ -84,8 +84,8 @@ Process:
       autoenableapp: 'VLC media player - Enable AutoUpdate'
       autoreleasejob: '@_AU-Rel_VLC media player'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIPNAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-VLC*.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'    
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\%DIP_SUBDIR%'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-VLC*.txt|%BMS_IMPORT_PATH_TST%\%DIPNAME%\%parsed_string%\DEV'    
 
 - Processor: EndOfCheckPhase

--- a/VLC/VLC-Win64.build.recipe.yaml
+++ b/VLC/VLC-Win64.build.recipe.yaml
@@ -29,23 +29,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the autopkg zip archive
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%filename%'
-    #extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourcepkt\%filename%'
+    #extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
     extract_file: '*'
     ignore_pattern: ''
     preserve_paths: 'True'
@@ -57,68 +52,68 @@ Process:
     - /C
     - dir
     - /b
-    #- '%BUILD_DIR%\%pkg_dir%\sourceunzipped\vlc-%version%\msi'
-    - '%BUILD_DIR%\%pkg_dir%\wixproject\vlc-%version%\msi'
+    #- '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\vlc-%version%\msi'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\vlc-%version%\msi'
     - '>'
     - wixfiles.txt
     exe_file: 'cmd.exe'
-    exe_folder: '%BUILD_DIR%\%pkg_dir%\helpers'
+    exe_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileMoverFromList
   Comment: Move the VLC build files to the build dir
   Arguments:
-    file_list: '%BUILD_DIR%\%pkg_dir%\helpers\wixfiles.txt'
-    #source_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\vlc-%version%\msi'
-    source_dir: '%BUILD_DIR%\%pkg_dir%\wixproject\vlc-%version%\msi'
-    target_dir: '%BUILD_DIR%\%pkg_dir%\wixproject'
+    file_list: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\wixfiles.txt'
+    #source_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\vlc-%version%\msi'
+    source_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\vlc-%version%\msi'
+    target_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
 
 # - Processor: FileMover
   # Comment: Move the VLC installer folder to the build dir
   # Arguments:
-    # target: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\'
-    # source: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\vlc-%version%\'
+    # target: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\'
+    # source: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\vlc-%version%\'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 # - Processor: com.github.NickETH.recipes.SharedProcessors/WixSettings
   # Comment: Define variables for the WIX build process to the config.wxi file
   # Arguments:
-    # preproc_file: '%BUILD_DIR%\%pkg_dir%\wixproject\config.wxi'
-    # template_file: '%BUILD_DIR%\%pkg_dir%\wixproject\config.wxi'
+    # preproc_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\config.wxi'
+    # template_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\config.wxi'
     # new_settings:
     # - define: 'SourceDir="%NAME%"'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSBuildRun
   Comment: Run the MSBuild script to generate the IrfanView MSI installer
   Arguments:
-    build_file: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%.build'
-    build_folder: '%BUILD_DIR%\%pkg_dir%\wixproject'
-    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%pkg_dir%\wixproject;SourceDir=%BUILD_DIR%\%pkg_dir%\wixproject\vlc-%version%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
+    build_file: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%.build'
+    build_folder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject'
+    build_property: BuildPlatform=%PLATFORM%;BuildName=%NAME%;BuildDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject;SourceDir=%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\vlc-%version%;version=%build_ver%;Platformstr=%PF_STRING%;LangStr=%LANG_STRING%
     build_target: WIX
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\adm\PFiles\VideoLAN\VLC\%NAME%.exe'
-    source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\vlc-%version%\%NAME%.exe'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\adm\PFiles\VideoLAN\VLC\%NAME%.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\vlc-%version%\%NAME%.exe'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -128,15 +123,15 @@ Process:
   Comment: Merges the WixFirewallCA-merge.msi with the main MSI-file
   Arguments:
     mode: -m
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
-    workfile: '%BUILD_DIR%\%pkg_dir%\helpers\WixFirewallCA-merge.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    workfile: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\WixFirewallCA-merge.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSITransformer
   Comment: Applies the Settings-Transform to the VLC.msi in the release folder
   Arguments:
     mode: -a
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
-    mst_paths: '%BUILD_DIR%\%pkg_dir%\helpers\VLC64-AutoPkg-cfg.mst'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    mst_paths: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\VLC64-AutoPkg-cfg.mst'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQL
   Arguments:
@@ -144,6 +139,6 @@ Process:
     - UPDATE `Property` SET `Property`.`Value`='%version%' WHERE `Property`.`Property`='ProductVersion'
     - UPDATE `Property` SET `Property`.`Value`='VLC media player %version% (64-bit)' WHERE `Property`.`Property`='ProductName'
     - UPDATE `Registry` SET `Registry`.`Value`='%AS_ver%' WHERE `Registry`.`Registry`='regHKLM11'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/VMware/VMwareTools-Win64.build.recipe.yaml
+++ b/VMware/VMwareTools-Win64.build.recipe.yaml
@@ -28,17 +28,12 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_64_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the MSI file from exe
   Arguments:
     archive_type: '#'
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_64_%build_ver%%LANG_STRING%\sourceunzipped'
     extract_file: '*.msi'
     preserve_paths: 'False'
     recursive: 'True'
@@ -46,31 +41,31 @@ Process:
 - Processor: FileFinder
   Comment: Get the filename of the extracted MSI file
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\*.msi'
+    pattern: '%BUILD_DIR%\%NAME%_64_%build_ver%%LANG_STRING%\sourceunzipped\*.msi'
 
 - Processor: FileMover
   Comment: Move the MSI file to the release dir.
   Arguments:
     overwrite: 'true'
     source: '%found_filename%'
-    target: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_64_%build_ver%%LANG_STRING%.msi'
+    target: '%BUILD_DIR%\%NAME%_64_%build_ver%%LANG_STRING%\release\%NAME%_64_%build_ver%%LANG_STRING%.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_64_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%%LANG_STRING%\read\create-log-%NAME%_64_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_64_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_64_%build_ver%%LANG_STRING%\read\readme-%NAME%_64_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: Copier
   Comment: Save a copy of the downloaded EXE to the build dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourcepkt\%match%'
+    destination_path: '%BUILD_DIR%\%NAME%_64_%build_ver%%LANG_STRING%\sourcepkt\%match%'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -82,6 +77,6 @@ Process:
       /j: '%NAME% %version% ML'
       /o: Version %version% for ETHZ ID. %us_date% by AutoPkg
       /t: '%NAME% %version% ML'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_64_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_64_%build_ver%%LANG_STRING%\release\%NAME%_64_%build_ver%_ML.msi'
 
 - Processor: EndOfCheckPhase

--- a/VMware/VMwareVMRC-Win.build.recipe.yaml
+++ b/VMware/VMwareVMRC-Win.build.recipe.yaml
@@ -27,16 +27,11 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the MSI file from exe
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourcepkt'
+    extract_dir: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\sourcepkt'
     extract_file: VMware-VMRC-*.exe
     preserve_paths: 'False'
     recursive: 'True'
@@ -44,7 +39,7 @@ Process:
 - Processor: FileFinder
   Comment: Get the full path to the downloaded installer
   Arguments:
-    pattern: '%BUILD_DIR%\%pkg_dir%\sourcepkt\VMware-VMRC-*.exe'
+    pattern: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\sourcepkt\VMware-VMRC-*.exe'
 
 - Processor: WindowsSignatureVerifier
   Arguments:
@@ -56,26 +51,26 @@ Process:
   Arguments:
     archive_type: '#'
     exe_path: '%found_filename%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    extract_dir: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\sourceunzipped'
     extract_file: '*.msi'
     preserve_paths: 'False'
 
 - Processor: Copier
   Comment: Copy the VMRC msi file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\release\%NAME%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
-    source_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\*.msi'
+    source_path: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\sourceunzipped\*.msi'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\read\create-log-%NAME%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\read\readme-%NAME%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -89,6 +84,6 @@ Process:
       /o: Version %version% for ETHZ ID. %us_date% by AutoPkg
       /p: Intel;1033
       /t: '%NAME% %version% ML'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_%build_ver%%LANG_STRING%.msi'
+    msi_path: '%BUILD_DIR%\%NAME%_%build_ver%%LANG_STRING%\release\%NAME%_%build_ver%%LANG_STRING%.msi'
 
 - Processor: EndOfCheckPhase

--- a/WhatsApp/WhatsAppDesktop-Win64.BMS.recipe.yaml
+++ b/WhatsApp/WhatsAppDesktop-Win64.BMS.recipe.yaml
@@ -132,7 +132,7 @@ Process:
       </ACTION>
       </ACTIONS>
       </baramundiDeployScript>
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_(Un-)Install.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%_(Un-)Install.bds'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/BMSImporter
   Comment: Import the Application into Baramundi (BMS)
@@ -187,9 +187,9 @@ Process:
       jobdescription: 'Mit WhatsApp Desktop können alle Funktionen von WhatsApp (Textnachrichten, Bild-, Video- und Ton-Dateien, Dokumente und Kontaktdaten und Video-Telefonie) auf Windows verwendet werden.'
       autoenableapp: '%NAME% - Enable AutoUpdate'
       autoreleasejob: '@_AU-Rel_%NAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons\*.*'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/WhatsApp/WhatsAppDesktop-Win64.build.recipe.yaml
+++ b/WhatsApp/WhatsAppDesktop-Win64.build.recipe.yaml
@@ -23,23 +23,18 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the WhatsApp msix package to the release dir
   Arguments:
     exe_path: '%pathname%'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\release\'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\'
     extract_file: WhatsApp_%version%_x64.msix
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/SevenZipExtractor
   Comment: Extract the WhatsApp msix package to the release dir
   Arguments:
-    exe_path: '%BUILD_DIR%\%pkg_dir%\release\WhatsApp_%version%_x64.msix'
-    extract_dir: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    exe_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\WhatsApp_%version%_x64.msix'
+    extract_dir: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\'
     extract_file: 'AppList.targetsize-256.png'
     recursive: true
     preserve_paths: false
@@ -52,20 +47,20 @@ Process:
     - move
     - /Y
     - '%RECIPE_CACHE_DIR%\downloads\*.*x'
-    - '%BUILD_DIR%\%pkg_dir%\release\'
+    - '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\'
     exe_file: 'cmd.exe'
     exe_folder: '%RECIPE_CACHE_DIR%'
     
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate Icon files for the Kiosk from Telegraf
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\AppList.targetsize-256.png'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\sourceunzipped\AppList.targetsize-256.png'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -75,13 +70,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\Create-log-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%version%%LANG_STRING%.txt'
     new_ver: '%version%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/WinMerge/WinMerge-Win64.build.recipe.yaml
+++ b/WinMerge/WinMerge-Win64.build.recipe.yaml
@@ -22,29 +22,24 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '4'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the WinMerge install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -52,27 +47,27 @@ Process:
   Comment: Extract the WinMerge installer
   Arguments:
     inno_path: '%pathname%'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     # inno_compiler: '*'
     ignore_errors: False
 
 # - Processor: FileFinder
   # Comment: Get the WinMerge exe file to extract the icons from
   # Arguments:
-    # pattern: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\bin\gimp-console-*.exe'
+    # pattern: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\{app}\bin\gimp-console-*.exe'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Generate the WinMerge icons for BMS Kiosk.
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    #source_app: '%BUILD_DIR%\%pkg_dir%\wixproject\%NAME%\%EXE_NAME%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\WinMergeU.exe'
+    #source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\wixproject\%NAME%\%EXE_NAME%'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\{app}\WinMergeU.exe'
     msi_icon_name: 'TGITIcon'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'

--- a/WinSCP/WinSCP-Win.build.recipe.yaml
+++ b/WinSCP/WinSCP-Win.build.recipe.yaml
@@ -22,38 +22,33 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the WinSCP install exe file to the release dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/InnoEditor
   Comment: Extract the WinSCP installer
   Arguments:
-    inno_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\'
+    inno_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.exe'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\'
     ignore_errors: False
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     composite_position: bl
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    # source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\_7zG.exe'
-    source_app: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\{app}\WinSCP.exe'
+    # source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\_7zG.exe'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\{app}\WinSCP.exe'
     # msi_icon_name: 'ProductIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -61,12 +56,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/XnView/XnView-Win.BMS.recipe.yaml
+++ b/XnView/XnView-Win.BMS.recipe.yaml
@@ -13,67 +13,9 @@ Input:
   DIP_SUBDIR: ML
 
 Process:
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: |
-      <?xml version="1.0" encoding="ISO-8859-1"?>
-      <baramundiDeployScript Version="2420" LastChange="ddaatteettiimmee">
-      <META>
-      <INFO Vendor="" Name="" Version="" Author="Autopkg" Comment=""/>
-      <STATICVARS LoadInstallIni="1">
-      <BMSVars></BMSVars>
-      </STATICVARS>
-      </META>
-      <ACTIONS>
-      <ACTION type="Comment" level="0" breakpoint="0" ignore_error="0" comment="1" is_included="0" logging_enabled="1">
-      <DATA>
-      <VALUE>Uninstall-Script forXnView (Inno-Setup)</VALUE>
-      </DATA>
-      </ACTION>
-      <ACTION type="SetX64Mode" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <MODE>1</MODE>
-      </DATA>
-      </ACTION>
-      <ACTION type="SetVar" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <VARNAME>AppUninstallString</VARNAME>
-      <VALUE>0</VALUE>
-      <OPTIONS>0</OPTIONS>
-      </DATA>
-      </ACTION>
-      <ACTION type="EvalVar" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <VARNAME>AppUninstallString</VARNAME>
-      <SOURCE>Registry</SOURCE>
-      <OPTIONS>0</OPTIONS>
-      <Properties><PropertyEntry><Param>Key</Param><Value>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\XnView_is1</Value></PropertyEntry><PropertyEntry><Param>Registry</Param><Value>HKEY_LOCAL_MACHINE</Value></PropertyEntry><PropertyEntry><Param>Value</Param><Value>UninstallString</Value></PropertyEntry></Properties></DATA>
-      </ACTION>
-      <ACTION type="EvalVar" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <VARNAME>AppUninstallLocation</VARNAME>
-      <SOURCE>Registry</SOURCE>
-      <OPTIONS>0</OPTIONS>
-      <Properties><PropertyEntry><Param>Key</Param><Value>SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\XnView_is1</Value></PropertyEntry><PropertyEntry><Param>Registry</Param><Value>HKEY_LOCAL_MACHINE</Value></PropertyEntry><PropertyEntry><Param>Value</Param><Value>Inno Setup: App Path</Value></PropertyEntry></Properties></DATA>
-      </ACTION>
-      <ACTION type="LaunchProcess" level="0" breakpoint="0" ignore_error="0" comment="0" is_included="0" logging_enabled="1">
-      <DATA>
-      <COMMAND>{AppUninstallString}</COMMAND>
-      <PARAM>/VERYSILENT /NORESTART</PARAM>
-      <RETURNCODES>0</RETURNCODES>
-      <VARNAME></VARNAME>
-      <PIDVARNAME></PIDVARNAME>
-      <OPTIONS>3</OPTIONS>
-      </DATA>
-      <CONDITION op1="{AppUninstallString}" op="DOESNOTMATCH" op2="NOTFOUND" options="0"/>
-      </ACTION>
-      </ACTIONS>
-      </baramundiDeployScript>
-    rename_var: bds_content
-
 # - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   # Arguments:
-    # input_string: '%bds_content%'
+    # input_string: '|'
     # pattern_replace:
     # - pattern: SSuubbssttiittuuttee
       # repl: '%parsed_string%&#92;ML&#92;%NAME%%PF_STRING%_%build_ver%_ML'
@@ -81,7 +23,7 @@ Process:
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
     #input_string: '%parsed_string%'
-    input_string: '%bds_content%'
+    input_string: '|'
     pattern_replace:
     - pattern: ddaatteettiimmee
       repl: '%us_date% %time%'
@@ -90,7 +32,7 @@ Process:
   Comment: Generate the install.bds in the release dir.
   Arguments:
     file_content: '%parsed_string%'
-    file_path: '%BUILD_DIR%\%pkg_dir%\release\u_%NAME%%PF_STRING%_%build_ver%.bds'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\u_%NAME%%PF_STRING%_%build_ver%.bds'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -170,9 +112,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
+    inst_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\*.*|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\%DIP_SUBDIR%'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%DIP_NAME%\bms_app_integration.json'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons\*.*'
+    read_file_src_dest: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\*-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt|%BMS_IMPORT_PATH_TST%\%DIP_NAME%\%parsed_string%\DEV'
 
 - Processor: EndOfCheckPhase

--- a/XnView/XnView-Win.build.recipe.yaml
+++ b/XnView/XnView-Win.build.recipe.yaml
@@ -48,29 +48,24 @@ Process:
     # recipe_path: '%RECIPE_PATH%'
     # ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%_ML'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\XnviewSetup.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\XnviewSetup.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/InnoEditor
   Arguments:
     inno_compiler: C:\Program Files (x86)\Inno Setup 6\ISCC.exe
-    inno_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\XnviewSetup.exe'
-    workfolder: '%BUILD_DIR%\%pkg_dir%\sourceunzipped'
+    inno_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped\XnviewSetup.exe'
+    workfolder: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\sourceunzipped'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/DateTimeStamps
 
 - Processor: Copier
   Comment: Copy the XnView install exe file to the build dir
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_%build_ver%_ML.exe'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\release\%NAME%_%build_ver%_ML.exe'
     overwrite: 'true'
     source_path: '%pathname%'
 
@@ -78,7 +73,7 @@ Process:
 - Processor: com.github.haircut.processors/AppIconExtractor
   Comment: Extract the XnView icons and generate BMS-Kiosk-Icons
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
@@ -86,7 +81,7 @@ Process:
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
     #source_app: '%pathname%'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\xnview256.png'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\helpers\xnview256.png'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -94,12 +89,12 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\create-log-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%_ML\read\readme-%NAME%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'

--- a/Zabbix/ZabbixAgent2SSL-Win64.build.recipe.yaml
+++ b/Zabbix/ZabbixAgent2SSL-Win64.build.recipe.yaml
@@ -24,27 +24,22 @@ Process:
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%NAME%%PF_STRING%_%build_ver%%LANG_STRING%'
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
+    destination_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\release\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\create-log-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
+    file_path: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\read\readme-%NAME%%PF_STRING%_%build_ver%%LANG_STRING%.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+'
 
@@ -52,14 +47,14 @@ Process:
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\Zabbix-256.png'
+    source_app: '%BUILD_DIR%\%NAME%%PF_STRING%_%build_ver%%LANG_STRING%\helpers\Zabbix-256.png'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%/Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%/Icon-Update-%NAME%.png'

--- a/Zoom/ZoomClient-Win.BMS.recipe.yaml
+++ b/Zoom/ZoomClient-Win.BMS.recipe.yaml
@@ -14,7 +14,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\release\%NAME%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -47,8 +47,8 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML%PF_STRING%'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    inst_file_src_dest: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML%PF_STRING%'
+    read_file_src_dest: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
     bms_app_integration:
     - appname: '%NAME%'
       bundles:

--- a/Zoom/ZoomClient-Win.build.recipe.yaml
+++ b/Zoom/ZoomClient-Win.build.recipe.yaml
@@ -25,52 +25,42 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Comment: Create the build environment
   Arguments:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read
-    org_ver: '%version%'
-    pkg_dir: ZoomClient_%version%_ML
+    org_ver: '%msi_value%'
+    pkg_dir: ZoomClient_%msi_value%_ML
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: ZoomClient_%version%_ML
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI file to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\release\%NAME%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI file to the build dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%.msi'
+    destination_path: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\sourceunzipped\%NAME%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\ZoomClient_256.ico'
+    source_app: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\helpers\ZoomClient_256.ico'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -78,13 +68,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-ZoomClient_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\read\create-log-ZoomClient_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-ZoomClient_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\ZoomClient_%msi_value%_ML\read\readme-ZoomClient_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 

--- a/Zoom/ZoomClient-Win64.BMS.recipe.yaml
+++ b/Zoom/ZoomClient-Win64.BMS.recipe.yaml
@@ -15,7 +15,7 @@ Process:
 - Processor: com.github.NickETH.recipes.SharedProcessors/MSIRunSQLget
   Arguments:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductCode'
-    msi_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    msi_path: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
 
 - Processor: com.github.sebtomasi.SharedProcessors/TextSubstituer
   Arguments:
@@ -48,9 +48,9 @@ Process:
     bms_serverport: '%BMS_SERVER_PORT%'
     bms_serverurl: '%BMS_SERVER1%'
     bms_username: '%BMS_USERNAME1%'
-    inst_file_src_dest: '%BUILD_DIR%\%pkg_dir%\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML%PF_STRING%'
-    read_file_src_dest: '%BUILD_DIR%\%pkg_dir%\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
-    icon_file_src: '%BUILD_DIR%\%pkg_dir%\icons\*.*'
+    inst_file_src_dest: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\release\*.ms?|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\ML%PF_STRING%'
+    read_file_src_dest: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\read\*-%NAME%%PF_STRING%_%build_ver%_ML.txt|%BMS_IMPORT_PATH_TST%\%NAME%\%parsed_string%\DEV'
+    icon_file_src: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\icons\*.*'
     json_file_dest: '%BMS_IMPORT_PATH_TST%\%NAME%\bms_app_integration.json'
     bms_app_integration:
     - appname: '%NAME%'

--- a/Zoom/ZoomClient-Win64.build.recipe.yaml
+++ b/Zoom/ZoomClient-Win64.build.recipe.yaml
@@ -26,52 +26,42 @@ Process:
     SQL_command: SELECT `Value` FROM `Property` WHERE `Property`='ProductVersion'
     msi_path: '%pathname%'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: '%msi_value%'
-    rename_var: version
-
 - Processor: com.github.NickETH.recipes.SharedProcessors/CreateNextBuild
   Comment: Create the build environment
   Arguments:
     BuildFiles: NextVerFiles.txt
     build_dir: '%BUILD_DIR%'
     folder_list: sourceunzipped:release:read:helpers
-    org_ver: '%version%'
-    pkg_dir: ZoomClient%PF_STRING%_%version%_ML
+    org_ver: '%msi_value%'
+    pkg_dir: ZoomClient%PF_STRING%_%msi_value%_ML
     recipe_dir: '%RECIPE_DIR%'
     recipe_path: '%RECIPE_PATH%'
     ver_fields: '3'
 
-- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
-  Arguments:
-    input_var: ZoomClient%PF_STRING%_%version%_ML
-    rename_var: pkg_dir
-
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI file to the release dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
+    destination_path: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\release\%NAME%%PF_STRING%_%build_ver%_ML.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: Copier
   Comment: Save a copy of the downloaded MSI file to the build dir.
   Arguments:
-    destination_path: '%BUILD_DIR%\%pkg_dir%\sourceunzipped\%NAME%.msi'
+    destination_path: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\sourceunzipped\%NAME%.msi'
     overwrite: 'true'
     source_path: '%pathname%'
 
 - Processor: com.github.haircut.processors/AppIconExtractor
   Arguments:
-    ICON_PATH: '%BUILD_DIR%\%pkg_dir%\icons'
+    ICON_PATH: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\icons'
     icon_file_number: 0
     # composite_padding: 20
     # composite_position: ul
     # composite_uninstall_path: '%RECIPE_CACHE_DIR%/Icon-Uninstall-%NAME%.png'
     # composite_uninstall_template: /Users/haircut/Documents/delete.png
     icon_output_path: '%ICON_PATH%\Icon-%NAME%.png'
-    source_app: '%BUILD_DIR%\%pkg_dir%\helpers\ZoomClient_256.ico'
+    source_app: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\helpers\ZoomClient_256.ico'
     #msi_icon_name: 'MainExecutableIcon.ico'
     composite_uninstall_path: '%ICON_PATH%\Icon-Uninstall-%NAME%.png'
     composite_update_path: '%ICON_PATH%\Icon-Update-%NAME%.png'
@@ -79,13 +69,13 @@ Process:
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-ZoomClient%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\read\create-log-ZoomClient%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
 - Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
   Arguments:
-    file_path: '%BUILD_DIR%\%pkg_dir%\read\readme-ZoomClient%PF_STRING%_%build_ver%_ML.txt'
+    file_path: '%BUILD_DIR%\ZoomClient%PF_STRING%_%msi_value%_ML\read\readme-ZoomClient%PF_STRING%_%build_ver%_ML.txt'
     new_ver: '%build_ver%'
     re_pattern: '[0-9]+\.[0-9]+\.[0-9]+'
 


### PR DESCRIPTION
The [sebtomasi-recipes](https://github.com/autopkg/sebtomasi-recipes/issues/26) repository is deprecated and will soon be archived, including the RenameVar shared processor.

At its core, the RenameVar processor just copies the value of one variable into another variable — which is something AutoPkg can do natively just by using variable substitution.

For example, this sequence of processors:

```yaml
- Processor: com.github.sebtomasi.SharedProcessors/RenameVar
  Arguments:
    input_var: '%NAME%_%build_ver%_ML'
    rename_var: pkg_dir

- Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
  Arguments:
    file_path: '%BUILD_DIR%\%pkg_dir%\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
    new_ver: '%build_ver%'
    re_pattern: '[0-9]+\.[0-9]+'
```

Is equivalent to this:

```yaml
- Processor: com.github.NickETH.recipes.SharedProcessors/FileDateVersionSubst
  Arguments:
    file_path: '%BUILD_DIR%\%NAME%_%build_ver%_ML\read\create-log-%NAME%%PF_STRING%_%build_ver%_ML.txt'
    new_ver: '%build_ver%'
    re_pattern: '[0-9]+\.[0-9]+'
```

Notice `%pkg_dir%` in the first is expanded to its components `%NAME%_%build_ver%_ML` in the second, with the same end result.

This pull request makes similar replacements throughout your recipes. **Note that I do not use AutoPkg on Windows, and I have not verified whether these modifications all work perfectly.** I've set the PR to allow edits by maintainers in case tweaks are needed based on your testing.

Once this pull request is merged in, you'll have one less dependency on the sebtomasi-recipes repository, and your recipes can continue working even after RenameVar no longer exists.

Thanks for considering!