### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/Bitwarden/Bitwarden-Desktop-Win64.download.recipe.yaml
+++ b/Bitwarden/Bitwarden-Desktop-Win64.download.recipe.yaml
@@ -18,6 +18,8 @@ Process:
   Arguments:
     filename: '%NAME%-x64.7z'
 
+- Processor: EndOfCheckPhase
+
 - Processor: StopProcessingIf
   Arguments:
     predicate: download_changed == False

--- a/Microsoft/Office2021LTSC-Win.download.recipe.yaml
+++ b/Microsoft/Office2021LTSC-Win.download.recipe.yaml
@@ -71,5 +71,3 @@ Process:
   Arguments:
     expected_subject: CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     input_path: '%pathname%'
-
-- Processor: EndOfCheckPhase

--- a/Microsoft/Office2024LTSC-Win64.download.recipe.yaml
+++ b/Microsoft/Office2024LTSC-Win64.download.recipe.yaml
@@ -71,5 +71,3 @@ Process:
   Arguments:
     expected_subject: CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US
     input_path: '%pathname%'
-
-- Processor: EndOfCheckPhase

--- a/OBS/OBS-Studio-Win64.download.recipe.yaml
+++ b/OBS/OBS-Studio-Win64.download.recipe.yaml
@@ -19,6 +19,8 @@ Process:
   Arguments:
     filename: '%NAME%-x64.exe'
 
+- Processor: EndOfCheckPhase
+
 - Processor: WindowsSignatureVerifier
   Arguments:
     expected_subject: CN="OBS Project, LLC", O="OBS Project, LLC", L=Sheridan, S=Wyoming, C=US, SERIALNUMBER=2023-001272252, OID.2.5.4.15=Private Organization, OID.1.3.6.1.4.1.311.60.2.1.2=Wyoming, OID.1.3.6.1.4.1.311.60.2.1.3=US

--- a/Python/Python-Win64.download.recipe.yaml
+++ b/Python/Python-Win64.download.recipe.yaml
@@ -20,6 +20,8 @@ Process:
     prefetch_filename: '%NAME%-x64.exe'
     url: '%match%'
 
+- Processor: EndOfCheckPhase
+
 - Processor: WindowsSignatureVerifier
   Arguments:
     expected_subject: CN=Python Software Foundation, O=Python Software Foundation, L=Beaverton, S=Oregon, C=US

--- a/WinMerge/WinMerge-Win64.download.recipe.yaml
+++ b/WinMerge/WinMerge-Win64.download.recipe.yaml
@@ -18,6 +18,8 @@ Process:
   Arguments:
     filename: '%NAME%-x64.exe'
 
+- Processor: EndOfCheckPhase
+
 - Processor: WindowsSignatureVerifier
   Arguments:
     expected_subject: CN=Takashi Sawanaka, O=Takashi Sawanaka, L=Chiba, S=Chiba, C=JP


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.