### PR TITLE
Use APLooseVersion instead of distutils

### DIFF
--- a/VMware/VMwareVMRC-Win.build.recipe.yaml
+++ b/VMware/VMwareVMRC-Win.build.recipe.yaml
@@ -1,7 +1,7 @@
 Description: Alters latest VMware VM Remote Console installer for Windows.
 Identifier: com.github.NickETH.recipes.build.VMwareVMRC-Win
 ParentRecipe: com.github.NickETH.recipes.download.VMwareVMRC-Win
-MinimumVersion: 1.3.1
+MinimumVersion: 2.0.1
 
 Input:
   NAME: VMwareVMRC

--- a/VMware/VMwareVMRC-Win.download.recipe.yaml
+++ b/VMware/VMwareVMRC-Win.download.recipe.yaml
@@ -1,6 +1,6 @@
 Description: Download recipe for VMware VMRC
 Identifier: com.github.NickETH.recipes.download.VMwareVMRC-Win
-MinimumVersion: 1.3.1
+MinimumVersion: 2.0.1
 
 Input:
   NAME: VMwareVMRC

--- a/VMware/VMwareVMRCURLProvider.py
+++ b/VMware/VMwareVMRCURLProvider.py
@@ -23,10 +23,10 @@ import gzip
 import os
 import sys
 import re
-from distutils.version import LooseVersion
 from xml.etree import ElementTree
 from xml.parsers.expat import ExpatError
 
+from autopkglib import APLooseVersion as LooseVersion
 from autopkglib import ProcessorError, URLGetter
 
 try:

--- a/VMware/VMwareWSURLProvider.py
+++ b/VMware/VMwareWSURLProvider.py
@@ -23,10 +23,10 @@ import os
 import sys
 import re
 import collections
-from distutils.version import LooseVersion
 from xml.etree import ElementTree
 from xml.parsers.expat import ExpatError
 
+from autopkglib import APLooseVersion as LooseVersion
 from autopkglib import ProcessorError, URLGetter
 
 try:


### PR DESCRIPTION
AutoPkg has provided `APLooseVersion` since version 2.0.1 as a drop-in replacement for `distutils.version.LooseVersion`.

This PR updates your processors and any consuming recipes to leverage `APLooseVersion` for version comparison, which enables your recipe(s) to continue working with a future version of AutoPkg that includes a Python 3.12 or 3.13 runtime and drops `distutils`.

For the dotted numeric versions these processors handle, the resulting ordering is unchanged; `APLooseVersion` only differs from `distutils` on uncommon inputs such as zero-equivalent versions of differing length (e.g. `1.0` vs `1.0.0`).
